### PR TITLE
Sa 291 - PT 1 Add Results Interaction

### DIFF
--- a/models/result_sic_only.py
+++ b/models/result_sic_only.py
@@ -1,0 +1,155 @@
+"""Module that provides the models for the result endpoint when based on SIC only.
+
+This module contains the request and response models for the result endpoint.
+It defines the structure of the data that can be sent to and received from the endpoint.
+
+IMPORTANT: This model will be removed in favour of the generic result API once the API is updated.
+
+"""
+
+from datetime import datetime
+from typing import Optional, Union
+
+from pydantic import BaseModel, Field
+
+
+class InputField(BaseModel):
+    """Model for input field data."""
+
+    field: str = Field(..., description="The field name")
+    value: str = Field(..., description="The field value")
+
+
+class FollowUpQuestion(BaseModel):
+    """Model for follow-up questions."""
+
+    id: str = Field(..., description="Question identifier")
+    text: str = Field(..., description="Question text")
+    type: str = Field(
+        ..., description="Question type (text or select)", pattern="^(text|select)$"
+    )
+    select_options: Optional[list[str]] = Field(
+        None, description="Options for select type questions"
+    )
+    response: str = Field(..., description="User's response to the question")
+
+
+class FollowUp(BaseModel):
+    """Model for follow-up data."""
+
+    questions: list[FollowUpQuestion] = Field(
+        ..., description="List of follow-up questions"
+    )
+
+
+class Candidate(BaseModel):
+    """Model for classification candidates."""
+
+    code: str = Field(..., description="The classification code")
+    description: str = Field(..., description="The classification description")
+    likelihood: float = Field(..., description="Confidence score between 0 and 1")
+
+
+class ClassificationResponse(BaseModel):
+    """Model for classification response."""
+
+    classified: bool = Field(..., description="Whether the input was classified")
+    code: str = Field(..., description="The classification code")
+    description: str = Field(..., description="The classification description")
+    reasoning: str = Field(..., description="Reasoning behind the classification")
+    candidates: list[Candidate] = Field(
+        ..., description="List of potential classifications"
+    )
+    follow_up: FollowUp = Field(..., description="Follow-up questions if needed")
+
+
+class PotentialDivision(BaseModel):
+    """Model for potential division data."""
+
+    code: str = Field(..., description="The division code")
+    title: str = Field(..., description="The division title")
+    detail: Optional[str] = Field(None, description="Additional division details")
+
+
+class PotentialCode(BaseModel):
+    """Model for potential code data."""
+
+    code: str = Field(..., description="The code")
+    description: str = Field(..., description="The code description")
+
+
+class LookupResponse(BaseModel):
+    """Model for lookup response."""
+
+    found: bool = Field(..., description="Whether matches were found")
+    potential_codes_count: int = Field(
+        ..., description="Number of potential codes found"
+    )
+    potential_divisions: list[PotentialDivision] = Field(
+        ..., description="List of potential divisions"
+    )
+    potential_codes: list[PotentialCode] = Field(
+        ..., description="List of potential codes"
+    )
+
+
+class SurveyAssistInteraction(BaseModel):
+    """Model for survey assist interaction."""
+
+    type: str = Field(
+        ...,
+        description="Interaction type (classify or lookup)",
+        pattern="^(classify|lookup)$",
+    )
+    flavour: str = Field(
+        ..., description="Classification flavour (sic or soc)", pattern="^(sic|soc)$"
+    )
+    time_start: datetime = Field(..., description="Start time of the interaction")
+    time_end: datetime = Field(..., description="End time of the interaction")
+    input: list[InputField] = Field(..., description="Input data for the interaction")
+    response: Union[ClassificationResponse, LookupResponse] = Field(
+        ..., description="Response from the interaction"
+    )
+
+
+class Response(BaseModel):
+    """Model for a single response."""
+
+    person_id: str = Field(..., description="Identifier for the person")
+    time_start: datetime = Field(..., description="Start time of the response")
+    time_end: datetime = Field(..., description="End time of the response")
+    survey_assist_interactions: list[SurveyAssistInteraction] = Field(
+        ..., description="List of survey assist interactions"
+    )
+
+
+class SurveyAssistResult(BaseModel):
+    """Model for the complete survey assist result."""
+
+    survey_id: str = Field(
+        ..., description="Identifier for the survey", examples=["test-survey-123"]
+    )
+    case_id: str = Field(
+        ..., description="Identifier for the case", examples=["test-case-456"]
+    )
+    user: str = Field(
+        ...,
+        description="User identifier in format 'name.surname'",
+        examples=["test.userSA187"],
+    )
+    time_start: datetime = Field(
+        ..., description="Start time of the survey", examples=["2024-03-19T10:00:00Z"]
+    )
+    time_end: datetime = Field(
+        ..., description="End time of the survey", examples=["2024-03-19T10:05:00Z"]
+    )
+    responses: list[Response] = Field(..., description="List of responses")
+
+
+class ResultResponse(BaseModel):
+    """Response model for result endpoints."""
+
+    message: str = Field(..., description="Response message")
+    result_id: Optional[str] = Field(
+        None, description="Unique identifier for the stored result"
+    )

--- a/models/result_sic_only.py
+++ b/models/result_sic_only.py
@@ -12,6 +12,10 @@ from typing import Optional, Union
 
 from pydantic import BaseModel, Field
 
+# The ui and api use pydantic models which are very similar
+# This needs to be refactored under a separate ticket
+# pylint: disable=duplicate-code
+
 
 class InputField(BaseModel):
     """Model for input field data."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "survey-assist-ui"
-version = "0.1.0a1"
+version = "0.1.0a2"
 description = "User Interface for Survey Assist API and Backend"
 authors = ["Steve Gibbard <steve.gibbard@ons.gov.uk>"]
 license = "MIT"

--- a/scripts/run_api.py
+++ b/scripts/run_api.py
@@ -11,6 +11,7 @@ import argparse
 import json
 import os
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
 from urllib.parse import urlparse
@@ -20,6 +21,9 @@ from survey_assist_utils.logging import get_logger
 
 sys.path.append(str(Path(__file__).resolve().parent.parent))
 
+# Disabling lint error as this is a test script to manually verify endpoints, not used
+# in production.
+# pylint: disable=wrong-import-position
 from models.result_sic_only import (
     Candidate,
     ClassificationResponse,
@@ -30,68 +34,231 @@ from models.result_sic_only import (
     SurveyAssistInteraction,
     SurveyAssistResult,
 )
-
-# Disabling lint error as this is a test script to manually verify endpoints, not used
-# in production.
 from utils.api_utils import APIClient  # pylint: disable=wrong-import-position
+from utils.map_results_utils import (
+    translate_session_to_model,
+)
+
+# pylint: disable=line-too-long
 
 logger = get_logger(__name__)
+
+
+def parse_z(ts: str) -> datetime:
+    """Convert an ISO-8601 'Z' timestamp to a UTC-aware datetime.
+
+    Args:
+        ts: Timestamp like '2025-08-19T10:00:00Z'.
+
+    Returns:
+        A timezone-aware datetime normalised to UTC.
+    """
+    return datetime.fromisoformat(ts.replace("Z", "+00:00")).astimezone(timezone.utc)
+
 
 # The API currently uses a model that only expects SIC in results
 result_sic_only: SurveyAssistResult = SurveyAssistResult(
     survey_id="test-survey-123",
     case_id="test-case-456",
     user="test.userSA187",
-    time_start="2025-08-19T10:00:00Z",
-    time_end="2025-08-19T10:05:00Z",
+    time_start=parse_z("2025-08-19T10:00:00Z"),
+    time_end=parse_z("2025-08-19T10:05:00Z"),
     responses=[
         Response(
             person_id="person-1",
-            time_start="2025-08-19T10:00:00Z",
-            time_end="2025-08-19T10:05:00Z",
+            time_start=parse_z("2025-08-19T10:00:00Z"),
+            time_end=parse_z("2025-08-19T10:05:00Z"),
             survey_assist_interactions=[
                 # --- classify interaction (SIC) ---
                 SurveyAssistInteraction(
                     type="classify",
                     flavour="sic",
-                    time_start="2025-08-19T10:00:00Z",
-                    time_end="2025-08-19T10:01:00Z",
+                    time_start=parse_z("2025-08-19T10:00:00Z"),
+                    time_end=parse_z("2025-08-19T10:01:00Z"),
                     input=[
                         InputField(field="job_title", value="Electrician"),
-                        InputField(field="job_description", value="Installing electrical systems"),
+                        InputField(
+                            field="job_description",
+                            value="Installing electrical systems",
+                        ),
                     ],
-                    response= ClassificationResponse(
-                            classified=True,
-                            code="43210",
-                            description="Electrical installation",
-                            candidates=[
-                                Candidate(code="43210", description="Electrical installation", likelihood=0.9),
-                                Candidate(code="43220", description="Plumbing, heat and air-conditioning installation", likelihood=0.2),
-                            ],
-                            reasoning="Role and duties align with electrical installation (SIC 43210).",
-                            follow_up=FollowUp(
-                                questions=[
-                                    FollowUpQuestion(
-                                        id="q1",
-                                        text="What type of premises do you mostly work in?",
-                                        type="select",
-                                        select_options=["Domestic", "Commercial", "Industrial"],
-                                        response="Commercial",
-                                    ),
-                                    FollowUpQuestion(
-                                        id="q2",
-                                        text="Do you primarily install or maintain systems?",
-                                        type="text",
-                                        response="Mostly install new systems.",
-                                    ),
-                                ]
+                    response=ClassificationResponse(
+                        classified=True,
+                        code="43210",
+                        description="Electrical installation",
+                        candidates=[
+                            Candidate(
+                                code="43210",
+                                description="Electrical installation",
+                                likelihood=0.9,
                             ),
-                        )
+                            Candidate(
+                                code="43220",
+                                description="Plumbing, heat and air-conditioning installation",
+                                likelihood=0.2,
+                            ),
+                        ],
+                        reasoning="Role and duties align with electrical installation (SIC 43210).",
+                        follow_up=FollowUp(
+                            questions=[
+                                FollowUpQuestion(
+                                    id="q1",
+                                    text="What type of premises do you mostly work in?",
+                                    type="select",
+                                    select_options=[
+                                        "Domestic",
+                                        "Commercial",
+                                        "Industrial",
+                                    ],
+                                    response="Commercial",
+                                ),
+                                FollowUpQuestion(
+                                    id="q2",
+                                    text="Do you primarily install or maintain systems?",
+                                    type="text",
+                                    response="Mostly install new systems.",
+                                    select_options=[],
+                                ),
+                            ]
+                        ),
+                    ),
                 ),
             ],
         )
     ],
 )
+
+# The following is mock data used by script, pytests have similar by design
+# pylint: disable=duplicate-code
+example_session_classify_result = {
+    "survey_result": {
+        "case_id": "test-case-xyz",
+        "responses": [
+            {
+                "person_id": "user.respondent-a",
+                "survey_assist_interactions": [
+                    {
+                        "flavour": "sic",
+                        "input": [
+                            {
+                                "field": "org_description",
+                                "value": "Farm providing food for shops and wholesalers",
+                            }
+                        ],
+                        "response": {
+                            "found": False,
+                            "potential_codes": [],
+                            "potential_codes_count": 0,
+                            "potential_divisions": [],
+                        },
+                        "time_end": "2025-09-05T08:12:21.861831Z",
+                        "time_start": "2025-09-05T08:12:18.275881Z",
+                        "type": "lookup",
+                    },
+                    {
+                        "flavour": "sic",
+                        "input": [
+                            {"field": "job_title", "value": "Farm Hand"},
+                            {
+                                "field": "job_description",
+                                "value": "I tend crops on a farm applying fertaliser and harvesting plants",
+                            },
+                            {
+                                "field": "org_description",
+                                "value": "Farm providing food for shops and wholesalers",
+                            },
+                        ],
+                        "response": [
+                            {
+                                "candidates": [
+                                    {
+                                        "code": "46210",
+                                        "descriptive": "Wholesale of grain, unmanufactured tobacco, seeds and animal feeds",
+                                        "likelihood": 0.6,
+                                    },
+                                    {
+                                        "code": "46390",
+                                        "descriptive": "Non-specialised wholesale of food, beverages and tobacco",
+                                        "likelihood": 0.4,
+                                    },
+                                ],
+                                "classified": False,
+                                "code": "46210",
+                                "description": "Wholesale of grain, unmanufactured tobacco, seeds and animal feeds",
+                                "follow_up": {
+                                    "questions": [
+                                        {
+                                            "id": "f1.1",
+                                            "response": "sells grain and animal feeds",
+                                            "select_options": [],
+                                            "text": "Does your farm primarily sell grain, seeds, animal feeds, or other types of food products?",
+                                            "type": "text",
+                                        },
+                                        {
+                                            "id": "f1.2",
+                                            "response": "wholesale of grain, unmanufactured tobacco, seeds and animal feeds",
+                                            "select_options": [
+                                                "Wholesale of grain, unmanufactured tobacco, seeds and animal feeds",
+                                                "Non-specialised wholesale of food, beverages and tobacco",
+                                                "None of the above",
+                                            ],
+                                            "text": "Which of these best describes your organisation's activities?",
+                                            "type": "select",
+                                        },
+                                    ]
+                                },
+                                "reasoning": "Follow-up needed to determine most appropriate SIC code.",
+                                "type": "sic",
+                            }
+                        ],
+                        "time_end": "2025-09-05T08:12:26.599931Z",
+                        "time_start": "2025-09-05T08:12:26.599931Z",
+                        "type": "classify",
+                    },
+                ],
+                "time_end": "2025-09-05T08:12:26.599931Z",
+                "time_start": "2025-09-05T08:12:06.412975Z",
+            }
+        ],
+        "survey_id": "tlfs_shape_tomorrow_prototype",
+        "time_end": "2025-09-05T08:12:26.599931Z",
+        "time_start": "2025-09-05T08:12:06.412975Z",
+        "user": "user.respondent-a",
+    }
+}
+
+example_session_lookup_result = {
+    "survey_result": {
+        "case_id": "test-case-xyz",
+        "responses": [
+            {
+                "person_id": "user.respondent-a",
+                "survey_assist_interactions": [
+                    {
+                        "flavour": "sic",
+                        "input": [{"field": "org_description", "value": "pubs"}],
+                        "response": {
+                            "found": True,
+                            "potential_codes": [],
+                            "potential_codes_count": 0,
+                            "potential_divisions": [],
+                        },
+                        "time_end": "2025-09-05T09:00:46.000783Z",
+                        "time_start": "2025-09-05T09:00:45.864491Z",
+                        "type": "lookup",
+                    }
+                ],
+                "time_end": "2025-09-05T09:00:46.000783Z",
+                "time_start": "2025-09-05T09:00:28.493081Z",
+            }
+        ],
+        "survey_id": "shape_tomorrow_prototype",
+        "time_end": "2025-09-05T09:00:46.000783Z",
+        "time_start": "2025-09-05T09:00:28.493081Z",
+        "user": "user.respondent-a",
+    }
+}
+
 
 def get_env_var(name: str) -> str:
     """Retrieves the value of an environment variable or raises an error if missing.
@@ -220,8 +387,7 @@ def post_classify(
 
 
 def post_result_sic_only(
-    client: APIClient,
-    result: SurveyAssistResult
+    client: APIClient, result: SurveyAssistResult
 ) -> Optional[dict]:
     """Sends a result to the Survey Assist API.
 
@@ -232,10 +398,14 @@ def post_result_sic_only(
     Returns:
         Optional[dict]: The result response dictionary if successful, else None.
     """
+    # result = translate_session_to_model(example_session_lookup_result)
+    result = translate_session_to_model(example_session_classify_result)
+
     response = client.post(
         "/survey-assist/result",
-        body=result_sic_only.model_dump(mode="json") #required for datetime
+        body=result.model_dump(mode="json"),  # required for datetime
     )
+
     if isinstance(response, dict):
         logger.info(f"Successfully saved response {response.get("result_id")}")
         return response
@@ -284,14 +454,12 @@ def main() -> None:
             logger.debug(json.dumps(config))
         return
 
-
     if args.action == "result":
         api_client = init_api_client()
         result_resp = post_result_sic_only(api_client, result_sic_only)
         if result_resp:
             logger.debug(json.dumps(result_resp))
         return
-
 
     job_title = prompt_input("Enter job title", "Kitchen Assistant")
     job_description = prompt_input(

--- a/survey_assist_ui/templates/summary_template.html
+++ b/survey_assist_ui/templates/summary_template.html
@@ -68,7 +68,7 @@
     "id": "submit-button",
     "text": "Submit",
     "variants": 'loader',
-    "url": url_for('main.index'),
+    "url": url_for('survey.survey_result'),
 }) }}
 
 {% endblock %}

--- a/survey_assist_ui/templates/thank_you.html
+++ b/survey_assist_ui/templates/thank_you.html
@@ -1,0 +1,55 @@
+{% extends "core.html" %}
+{% from "components/button/_macro.njk" import onsButton %}
+{% from "components/panel/_macro.njk" import onsPanel %}
+{% from "components/label/_macro.njk" import onsLabel %}
+
+{%
+    set pageConfig = {
+        "meta": {
+            "canonicalUrl": "/",
+            "description": "/",
+        },
+        "header": {
+            "title": 'Response Submitted',
+            "orgLogoHref": 'https://www.ons.gov.uk',
+            "titleLogoHref": "/",
+            "mastheadLogo": {
+              "large": '<img class="logo" src="https://cdn.ons.gov.uk/assets/images/ons-logo/v2/ons-logo.svg" height="150" width="250" alt="Office for National Statistics logo">'
+            },
+            "titleLogo": "/",
+            "navigation": navigation.navigation,
+        },
+        "breadcrumbs": {
+            "ariaLabel": 'Breadcrumbs',
+            "itemsList": [
+                {
+                    "url": url_for("survey.summary"),
+                    "text": 'Previous'
+                }
+            ]
+        }
+    }
+%}
+
+{% block main %}
+{{
+    onsPanel({
+        "variant": 'success',
+        "id": 'success-id',
+        "iconType": 'check',
+        "body": 'Information has been successfully submitted',
+        "spacious": true
+    })
+}}
+<br></br>
+{{ onsLabel({
+    "text": 'Thank you for your response to the '+survey+' survey!',
+    "classes": 'ons-u-mb-l'
+}) }}
+<p></p>
+{{ onsButton({
+    "id": "submit-button",
+    "text": "Finish",
+    "url": url_for('main.index'),
+}) }}
+{% endblock %}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -419,3 +419,145 @@ def make_generic_classification_response():
         )
 
     return _make
+
+
+@pytest.fixture()
+def survey_result_session() -> dict[str, Any]:
+    """Provide a realistic example session payload mirroring production shape.
+
+    Returns:
+        dict[str, Any]: A session dict containing a 'survey_result' key with nested responses.
+    """
+    return {
+        "survey_result": {
+            "case_id": "test-case-xyz",
+            "responses": [
+                {
+                    "person_id": "user.respondent-a",
+                    "survey_assist_interactions": [
+                        {
+                            "flavour": "sic",
+                            "input": [
+                                {
+                                    "field": "org_description",
+                                    "value": "Farm providing food for shops and wholesalers",
+                                }
+                            ],
+                            "response": {
+                                "found": False,
+                                "potential_codes": [],
+                                "potential_codes_count": 0,
+                                "potential_divisions": [],
+                            },
+                            "time_end": "2025-09-05T08:12:21.861831Z",
+                            "time_start": "2025-09-05T08:12:18.275881Z",
+                            "type": "lookup",
+                        },
+                        {
+                            "flavour": "sic",
+                            "input": [
+                                {"field": "job_title", "value": "Farm Hand"},
+                                {
+                                    "field": "job_description",
+                                    "value": "I tend crops on a farm applying fertaliser and harvesting plants",
+                                },
+                                {
+                                    "field": "org_description",
+                                    "value": "Farm providing food for shops and wholesalers",
+                                },
+                            ],
+                            "response": [
+                                {
+                                    "candidates": [
+                                        {
+                                            "code": "46210",
+                                            "descriptive": "Wholesale of grain, unmanufactured tobacco, seeds and animal feeds",
+                                            "likelihood": 0.6,
+                                        },
+                                        {
+                                            "code": "46390",
+                                            "descriptive": "Non-specialised wholesale of food, beverages and tobacco",
+                                            "likelihood": 0.4,
+                                        },
+                                    ],
+                                    "classified": False,
+                                    "code": "46210",
+                                    "description": "Wholesale of grain, unmanufactured tobacco, seeds and animal feeds",
+                                    "follow_up": {
+                                        "questions": [
+                                            {
+                                                "id": "f1.1",
+                                                "response": "sells grain and animal feeds",
+                                                "select_options": [],
+                                                "text": "Does your farm primarily sell grain, seeds, animal feeds, or other types of food products?",
+                                                "type": "text",
+                                            },
+                                            {
+                                                "id": "f1.2",
+                                                "response": "wholesale of grain, unmanufactured tobacco, seeds and animal feeds",
+                                                "select_options": [
+                                                    "Wholesale of grain, unmanufactured tobacco, seeds and animal feeds",
+                                                    "Non-specialised wholesale of food, beverages and tobacco",
+                                                    "None of the above",
+                                                ],
+                                                "text": "Which of these best describes your organisation's activities?",
+                                                "type": "select",
+                                            },
+                                        ]
+                                    },
+                                    "reasoning": "Follow-up needed to determine most appropriate SIC code.",
+                                    "type": "sic",
+                                }
+                            ],
+                            "time_end": "2025-09-05T08:12:26.599931Z",
+                            "time_start": "2025-09-05T08:12:26.599931Z",
+                            "type": "classify",
+                        },
+                    ],
+                    "time_end": "2025-09-05T08:12:26.599931Z",
+                    "time_start": "2025-09-05T08:12:06.412975Z",
+                }
+            ],
+            "survey_id": "shape_tomorrow_prototype",
+            "time_end": "2025-09-05T08:12:26.599931Z",
+            "time_start": "2025-09-05T08:12:06.412975Z",
+            "user": "user.respondent-a",
+        }
+    }
+
+
+# Simulate a user answereing org description question with an answer that is in the lookup data
+@pytest.fixture()
+def survey_result_session_lookup_found() -> dict[str, Any]:
+    """Mock survey result when SIC lookup finds a match."""
+    return {
+        "survey_result": {
+            "case_id": "test-case-xyz",
+            "responses": [
+                {
+                    "person_id": "user.respondent-a",
+                    "survey_assist_interactions": [
+                        {
+                            "flavour": "sic",
+                            "input": [{"field": "org_description", "value": "pubs"}],
+                            "response": {
+                                "found": True,
+                                "potential_codes": [],
+                                "potential_codes_count": 0,
+                                "potential_divisions": [],
+                            },
+                            "time_end": "2025-09-05T09:00:46.000783Z",
+                            "time_start": "2025-09-05T09:00:45.864491Z",
+                            "type": "lookup",
+                        }
+                    ],
+                    "time_end": "2025-09-05T09:00:46.000783Z",
+                    "time_start": "2025-09-05T09:00:28.493081Z",
+                }
+            ],
+            "survey_id": "shape_tomorrow_prototype",
+            "time_end": "2025-09-05T09:00:46.000783Z",
+            "time_start": "2025-09-05T09:00:28.493081Z",
+            "user": "user.respondent-a",
+        }
+    }

--- a/tests/test_map_results_utils.py
+++ b/tests/test_map_results_utils.py
@@ -1,0 +1,168 @@
+"""Tests for translate_session_to_model without patching subfunctions.
+
+This test validates the complete mapping pipeline:
+- Top-level SurveyAssistResult fields are copied correctly.
+- Responses are built with preserved ordering.
+- Each SurveyAssistInteraction maps 'input' fields, timestamps, flavour, and type.
+- 'classify' interactions map to a ClassificationResponse with:
+  - candidates -> Candidate[], ensuring 'descriptive' is used for description fallback.
+  - follow_up -> FollowUp with FollowUpQuestion[], ensuring empty select_options => None.
+- 'lookup' interactions map to a LookupResponse with empty collections as appropriate.
+
+Running:
+    poetry run pytest -k translate_session_to_model_e2e -q
+"""
+
+# ruff: noqa: PLR2004
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Literal
+
+import pytest
+
+from models.result_sic_only import (
+    Candidate,
+    ClassificationResponse,
+    FollowUp,
+    FollowUpQuestion,
+    InputField,
+    LookupResponse,
+    Response,
+    SurveyAssistInteraction,
+    SurveyAssistResult,
+)
+from utils.map_results_utils import translate_session_to_model
+
+
+def _parse_z(ts: str) -> datetime:
+    """Parse an ISO8601 string with trailing 'Z' into a UTC-aware datetime.
+
+    Args:
+        ts (str): Timestamp in ISO8601 format, e.g. '2025-09-05T08:12:06.412975Z'.
+
+    Returns:
+        datetime: A timezone-aware datetime in UTC.
+    """
+    # datetime.fromisoformat does not accept 'Z', so normalise to '+00:00'
+    return datetime.fromisoformat(ts.replace("Z", "+00:00")).astimezone(timezone.utc)
+
+
+Scenario = Literal["lookup_and_classify", "lookup_only"]
+
+
+@pytest.mark.utils
+@pytest.mark.parametrize(
+    ("fixture_name", "scenario"),
+    [
+        ("survey_result_session", "lookup_and_classify"),
+        ("survey_result_session_lookup_found", "lookup_only"),
+    ],
+    ids=["lookup_then_classify", "lookup_only"],
+)
+# pylint: disable=too-many-statements
+def test_translate_session_to_model_e2e(  # noqa: PLR0915
+    request: pytest.FixtureRequest,
+    fixture_name: str,
+    scenario: Scenario,
+) -> None:
+    """Run the same end-to-end assertions over multiple input scenarios.
+
+    Args:
+        request (pytest.FixtureRequest): Pytest request object used to resolve the fixture by name.
+        fixture_name (str): The fixture name holding the session payload.
+        scenario (Scenario): Scenario discriminator for focused assertions.
+    """
+    session_payload: dict[str, Any] = request.getfixturevalue(fixture_name)
+    result = translate_session_to_model(session_payload)
+
+    # --- Top-level assertions (common) ---
+    assert isinstance(result, SurveyAssistResult)
+    assert result.survey_id == "shape_tomorrow_prototype"
+    assert result.case_id == "test-case-xyz"
+    assert result.user == "user.respondent-a"
+
+    # Extract expected top-level timestamps from the input for robustness
+    sr = session_payload["survey_result"]
+    assert result.time_start == _parse_z(sr["time_start"])
+    assert result.time_end == _parse_z(sr["time_end"])
+
+    # --- Response assertions (common) ---
+    assert isinstance(result.responses, list) and len(result.responses) == 1
+    r0 = result.responses[0]
+    assert isinstance(r0, Response)
+    assert r0.person_id == sr["responses"][0]["person_id"]
+    assert r0.time_start == _parse_z(sr["responses"][0]["time_start"])
+    assert r0.time_end == _parse_z(sr["responses"][0]["time_end"])
+
+    # --- Interactions (scenario-specific) ---
+    interactions = r0.survey_assist_interactions
+    assert isinstance(interactions, list) and len(interactions) >= 1
+    assert all(isinstance(i, SurveyAssistInteraction) for i in interactions)
+
+    # Always validate the first (lookup) interaction
+    i_lookup = interactions[0]
+    assert i_lookup.type == "lookup"
+    assert i_lookup.flavour == "sic"
+    assert [(inp.field, inp.value) for inp in i_lookup.input] == [
+        (
+            sr["responses"][0]["survey_assist_interactions"][0]["input"][0]["field"],
+            sr["responses"][0]["survey_assist_interactions"][0]["input"][0]["value"],
+        )
+    ]
+    assert i_lookup.time_start == _parse_z(
+        sr["responses"][0]["survey_assist_interactions"][0]["time_start"]
+    )
+    assert i_lookup.time_end == _parse_z(
+        sr["responses"][0]["survey_assist_interactions"][0]["time_end"]
+    )
+    assert isinstance(i_lookup.response, LookupResponse)
+    assert isinstance(i_lookup.input[0], InputField)
+    # Lookup response expected to mirror payload booleans and be empty collections by default
+    assert i_lookup.response.potential_codes_count == int(
+        sr["responses"][0]["survey_assist_interactions"][0]["response"][
+            "potential_codes_count"
+        ]
+    )
+    assert i_lookup.response.found is bool(
+        sr["responses"][0]["survey_assist_interactions"][0]["response"]["found"]
+    )
+    assert i_lookup.response.potential_divisions == []
+    assert i_lookup.response.potential_codes == []
+
+    if scenario == "lookup_and_classify":
+        # There must be a second interaction with full classification content
+        assert len(interactions) == 2
+        i_classify = interactions[1]
+        assert i_classify.type == "classify"
+        assert i_classify.flavour == "sic"
+        assert i_classify.time_start == _parse_z(
+            sr["responses"][0]["survey_assist_interactions"][1]["time_start"]
+        )
+        assert i_classify.time_end == _parse_z(
+            sr["responses"][0]["survey_assist_interactions"][1]["time_end"]
+        )
+        assert isinstance(i_classify.response, ClassificationResponse)
+        cr = i_classify.response
+
+        # Candidate list presence and types
+        assert isinstance(cr.candidates, list) and len(cr.candidates) == 2
+        assert all(isinstance(c, Candidate) for c in cr.candidates)
+        # Spot-check values and coercions
+        assert cr.code == "46210"
+        assert isinstance(cr.classified, bool)
+        assert isinstance(cr.reasoning, str)
+
+        # Follow-up questions
+        assert isinstance(cr.follow_up, FollowUp)
+        qs = cr.follow_up.questions
+        assert isinstance(qs, list) and len(qs) == 2
+        assert all(isinstance(q, FollowUpQuestion) for q in qs)
+        # Empty select_options => None per mapper
+        assert qs[0].select_options is None
+        # Non-empty list preserved
+        assert isinstance(qs[1].select_options, list) and len(qs[1].select_options) == 3
+    else:
+        # lookup_only: ensure only one interaction present and found=True
+        assert len(interactions) == 1
+        assert i_lookup.response.found is True

--- a/utils/map_results_utils.py
+++ b/utils/map_results_utils.py
@@ -1,0 +1,194 @@
+"""Utility functions for Flask application to map results structures.
+
+This module provides helper functions for mapping results.
+Internally the data is stored to accomodate SIC, SOC and Lookup results,
+it needs to be translated to the API format which only supports SIC and
+Lookup results.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from models.result_sic_only import (
+    Candidate,
+    ClassificationResponse,
+    FollowUp,
+    FollowUpQuestion,
+    InputField,
+    LookupResponse,
+    PotentialCode,
+    PotentialDivision,
+    Response,
+    SurveyAssistInteraction,
+    SurveyAssistResult,
+)
+
+
+def _map_follow_up(fu: dict[str, Any] | None) -> FollowUp | None:
+    """Convert a follow-up dictionary to a FollowUp model.
+
+    Args:
+        fu (dict[str, Any] | None): The follow-up dictionary or None.
+
+    Returns:
+        FollowUp | None: The FollowUp model or None if input is None.
+    """
+    if not fu:
+        return None
+    return FollowUp(
+        questions=[
+            FollowUpQuestion(
+                id=q["id"],
+                text=q["text"],
+                type=q["type"],
+                select_options=(q.get("select_options") or None),
+                response=q["response"],
+            )
+            for q in fu.get("questions", [])
+        ]
+    )
+
+
+def _map_candidates(cands: list[dict[str, Any]]) -> list[Candidate]:
+    """Convert a list of candidate dictionaries to Candidate models.
+
+    Args:
+        cands (list[dict[str, Any]]): List of candidate dictionaries.
+
+    Returns:
+        list[Candidate]: List of Candidate models.
+    """
+    return [
+        Candidate(
+            code=c["code"],
+            description=c.get("description") or c.get("descriptive") or "",
+            likelihood=float(c["likelihood"]),
+        )
+        for c in cands
+    ]
+
+
+def _map_classify_response(resp_list: list[dict[str, Any]]) -> ClassificationResponse:
+    """Convert a list of classification response dicts to a ClassificationResponse model.
+
+    Args:
+        resp_list (list[dict[str, Any]]): List of classification response dicts.
+
+    Returns:
+        ClassificationResponse: The mapped ClassificationResponse model.
+
+    Raises:
+        ValueError: If the response list does not contain exactly one item.
+    """
+    if len(resp_list) != 1:
+        raise ValueError(
+            f"Expected exactly one classification response, got {len(resp_list)}"
+        )
+
+    chosen = resp_list[0]
+    return ClassificationResponse(
+        classified=bool(chosen["classified"]),
+        code=chosen["code"],
+        description=chosen["description"],
+        reasoning=chosen.get("reasoning", ""),
+        candidates=_map_candidates(chosen.get("candidates", [])),
+        follow_up=_map_follow_up(chosen.get("follow_up")) or FollowUp(questions=[]),
+    )
+
+
+def _map_lookup_response(resp: dict[str, Any]) -> LookupResponse:
+    """Convert a lookup response dictionary to a LookupResponse model.
+
+    Args:
+        resp (dict[str, Any]): The lookup response dictionary.
+
+    Returns:
+        LookupResponse: The mapped LookupResponse model.
+    """
+    return LookupResponse(
+        found=bool(resp["found"]),
+        potential_codes_count=int(resp.get("potential_codes_count", 0)),
+        potential_divisions=[
+            PotentialDivision(
+                code=d["code"],
+                title=d["title"],
+                detail=d.get("detail"),
+            )
+            for d in resp.get("potential_divisions", [])
+        ],
+        potential_codes=[
+            PotentialCode(
+                code=c["code"],
+                description=c["description"],
+            )
+            for c in resp.get("potential_codes", [])
+        ],
+    )
+
+
+ResponseModel = ClassificationResponse | LookupResponse
+
+
+def _map_interaction(it: dict[str, Any]) -> SurveyAssistInteraction:
+    """Convert an interaction dictionary to a SurveyAssistInteraction model.
+
+    Args:
+        it (dict[str, Any]): The interaction dictionary.
+
+    Returns:
+        SurveyAssistInteraction: The mapped SurveyAssistInteraction model.
+    """
+    it_type = it["type"]  # "classify" | "lookup"
+    flavour = it["flavour"]
+    response_obj: ResponseModel
+
+    inputs = [
+        InputField(field=i["field"], value=i["value"]) for i in it.get("input", [])
+    ]
+
+    if it_type == "classify":
+        response_obj = _map_classify_response(it.get("response", []))
+    else:
+        response_obj = _map_lookup_response(it.get("response", {}))
+
+    return SurveyAssistInteraction(
+        type=it_type,
+        flavour=flavour,
+        time_start=it["time_start"],
+        time_end=it["time_end"],
+        input=inputs,
+        response=response_obj,
+    )
+
+
+def translate_session_to_model(session: dict[str, Any]) -> SurveyAssistResult:
+    """Translate the internal `survey_result` dict into a `SurveyAssistResult` model.
+
+    Args:
+        session (dict[str, Any]): The session dictionary containing survey results.
+
+    Returns:
+        SurveyAssistResult: The mapped SurveyAssistResult model.
+    """
+    sr = session.get("survey_result", session)
+
+    return SurveyAssistResult(
+        survey_id=sr["survey_id"],
+        case_id=sr["case_id"],
+        user=sr["user"],
+        time_start=sr["time_start"],
+        time_end=sr["time_end"],
+        responses=[
+            Response(
+                person_id=r["person_id"],
+                time_start=r["time_start"],
+                time_end=r["time_end"],
+                survey_assist_interactions=[
+                    _map_interaction(it)
+                    for it in r.get("survey_assist_interactions", [])
+                ],
+            )
+            for r in sr.get("responses", [])
+        ],
+    )

--- a/utils/survey_assist_utils.py
+++ b/utils/survey_assist_utils.py
@@ -17,6 +17,7 @@ from models.api_map import (
 from models.classify import GenericClassificationResponse
 from models.question import Question
 from models.result import FollowUpQuestion
+from models.result_sic_only import ResultResponse, SurveyAssistResult
 from utils.app_types import SurveyAssistFlask
 from utils.session_utils import (
     add_classify_interaction,
@@ -43,7 +44,7 @@ def classify(
         org_description (str): The organisation description to classify.
 
     Returns:
-        tuple[dict, datetime] | None: A tuple containing the classification response
+        tuple[GenericClassificationResponse, datetime] | None: A tuple containing the classification response
         and the classification start time, or None and start_time if classification fails.
     """
     app = cast(SurveyAssistFlask, current_app)
@@ -68,6 +69,34 @@ def classify(
     except ValidationError as e:
         logger.error(f"Validation error in classification response: {e}")
         return None, start_time
+
+
+
+# This option is added to interwork with the initial API that only supports SIC
+def result_sic_only(
+    result: SurveyAssistResult
+) -> ResultResponse | None:
+    """Classifies the given parameters using the API client.
+
+    Args:
+        result (GenericSurveyAssistResult): The result body to send to Survey Assist.
+
+    Returns:
+        ResultResponse | None: result response or None if result fails.
+    """
+    app = cast(SurveyAssistFlask, current_app)
+    api_client = app.api_client
+    response = api_client.post(
+        "/survey-assist/result",
+        body=result.model_dump(mode="json"),
+    )
+
+    try:
+        validated_response = ResultResponse.model_validate(response)
+        return validated_response
+    except ValidationError as e:
+        logger.error(f"Validation error in result response: {e}")
+        return None
 
 
 def get_next_followup(

--- a/utils/survey_assist_utils.py
+++ b/utils/survey_assist_utils.py
@@ -44,7 +44,8 @@ def classify(
         org_description (str): The organisation description to classify.
 
     Returns:
-        tuple[GenericClassificationResponse, datetime] | None: A tuple containing the classification response
+        tuple[GenericClassificationResponse, datetime] | None: A tuple containing the classification
+        response.
         and the classification start time, or None and start_time if classification fails.
     """
     app = cast(SurveyAssistFlask, current_app)
@@ -71,11 +72,8 @@ def classify(
         return None, start_time
 
 
-
 # This option is added to interwork with the initial API that only supports SIC
-def result_sic_only(
-    result: SurveyAssistResult
-) -> ResultResponse | None:
+def result_sic_only(result: SurveyAssistResult) -> ResultResponse | None:
     """Classifies the given parameters using the API client.
 
     Args:


### PR DESCRIPTION
# 📌 Enable Saving Results to Survey Assist API

## ✨ Summary

This change introduces the capability to save results to the /results endpoint in the Survey Assist API. CLI based test scripts are updated to allow a result to be sent, utility functions are introduced to map from the GenericSurveyAssistResult structure (used by the UI to stroe results) to the SurveyAssistResult model (used by the backend API). A hook is added to send the result at the end of the survey and display a "Thank You" page. Unit tests are added.

## 📜 Changes Introduced

**model/result_sic_only.py** - This is a short term model (we need to refactor the pydantic models) used specifically to send a result that only contains SIC information.  This is to match with the expectation of the API.

**scripts/run_api.py** - command line handler is updated to allow a mocked result to be sent to the API for ease of test.

**routes/survey.py** - survey_result and thank_you routes are added to send a result to the api and then display an appropriate submission screen.  Note: error handling will come in a later PR.

**utils/map_results_utils.py** - utility functions to map from generic result model (used by UI) to sic only result model (expected by API. A later piece of work will update the API to expect generic result model and UI and API will converge to using the same pydantic definitions.

tests are updated to verify above.


- [x] Feature implementation (feat:)
- [x] Updates to tests and/or documentation
- n/a Terraform changes (if applicable)

## ✅ Checklist

> **Please confirm you've completed these checks before requesting a review.**

- [x] Code is formatted using **Black**
- [x] Imports are sorted using **isort**
- [x] Code passes linting with **Ruff**, **Pylint**, and **Mypy**
- [x] Security checks pass using **Bandit**
- [x] Tests are written and pass using **pytest**
- [x] Terraform files (if applicable) follow best practices and have been validated (`terraform fmt` & `terraform validate`)
- [x] DocStrings follow Google-style and are added as per Pylint recommendations
- [x] Documentation has been updated if needed

## 🔍 How to Test
The code is available in the sandbox environment in GCP you can test against this image or locally as per your preference.
 
Running through the survey should end with a Thank You page being displayed. 

Navigating to the appropriate bucket in the appropriate GCP project will show a test response (shape_tomorrow_prototype/user.respondent-a/DATE/HH-MM-SS.json)

```bash
make all-tests
```