### PR TITLE
feat(ui): configurable display of consent screen

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "survey-assist-ui"
-version = "0.1.0a4"
+version = "0.1.0a5"
 description = "User Interface for Survey Assist API and Backend"
 authors = ["Steve Gibbard <steve.gibbard@ons.gov.uk>"]
 license = "MIT"

--- a/survey_assist_ui/__init__.py
+++ b/survey_assist_ui/__init__.py
@@ -10,7 +10,7 @@ Attributes:
 import os
 from urllib.parse import urlparse
 
-from flask import json, request
+from flask import request
 from flask_misaka import Misaka
 from survey_assist_utils.api_token.jwt_utils import check_and_refresh_token
 from survey_assist_utils.logging import get_logger
@@ -18,6 +18,7 @@ from survey_assist_utils.logging import get_logger
 from survey_assist_ui.routes import register_blueprints
 from utils.api_utils import APIClient
 from utils.app_types import SurveyAssistFlask
+from utils.app_utils import load_survey_definition
 
 from .versioning import get_app_version
 
@@ -59,23 +60,7 @@ def create_app(test_config: dict | None = None) -> SurveyAssistFlask:
     )
     flask_app.config["JSON_DEBUG"] = os.getenv("JSON_DEBUG", "false").lower() == "true"
 
-    # Load the survey definition
-    with open(
-        "survey_assist_ui/survey/survey_definition.json", encoding="utf-8"
-    ) as file:
-        survey_definition = json.load(file)
-        flask_app.survey_title = survey_definition.get(
-            "survey_title", "Survey Assist Example"
-        )
-
-        survey_intro = survey_definition.get("survey_intro", {})
-        if isinstance(survey_intro, dict):
-            flask_app.survey_intro = survey_intro.get("enabled", False)
-        else:
-            flask_app.survey_intro = False
-
-        flask_app.questions = survey_definition["questions"]
-        flask_app.survey_assist = survey_definition["survey_assist"]
+    load_survey_definition(flask_app, "survey_assist_ui/survey/survey_definition.json")
 
     register_blueprints(flask_app)
 

--- a/survey_assist_ui/survey/survey_definition.json
+++ b/survey_assist_ui/survey/survey_definition.json
@@ -189,7 +189,7 @@
     "guidance_enabled": true,
     "guidance_text": "Automated follow-up question.", 
     "consent": {
-      "required": true,
+      "required": false,
       "question_id": "c1",
       "title": "Survey Assist Consent",
       "question_name": "survey_assist_consent",

--- a/survey_assist_ui/templates/question_template.html
+++ b/survey_assist_ui/templates/question_template.html
@@ -78,6 +78,7 @@
         
         {{ onsButton({
             "id": "save-values-button",
+            "variants": 'loader',
             "text": button_text,
             }) 
         }}

--- a/tests/test_survey_utils.py
+++ b/tests/test_survey_utils.py
@@ -78,46 +78,48 @@ def test_update_session_and_redirect_to_next_question(
 @pytest.mark.utils
 def test_update_session_and_redirect_to_survey_assist_consent(app):
     """Tests redirection to the survey_assist_consent page when interaction conditions match."""
-    test_question = {
-        "question_id": "job_role_q",
-        "question_name": "job_role",
-        "question_text": "What is your job role?",
-        "response_type": "text",
-        "response_options": [],
-        "response_name": "job-role",
-        "used_for_classifications": True,
-        "placeholder_field": "job_title",
-    }
-
-    with app.test_request_context(method="POST", data={"job-role": "Engineer"}):
-        interactions = [{"after_question_id": "job_role_q"}]
-        survey_assist = {"enabled": True, "interactions": interactions}
-        # Prepare the session for the correct branching
-        session["current_question_index"] = 0
-        session["response"] = {"job_title": "Engineer"}
-
-        # Disable duplicate code check as the test needs to match the intent
-        # pylint: disable=R0801
-        session["survey_iteration"] = {
-            "user": "",
-            "questions": [],
-            "time_start": None,
-            "time_end": None,
-            "survey_assist_time_start": None,
-            "survey_assist_time_end": None,
+    with app.app_context():
+        app.show_consent = True
+        test_question = {
+            "question_id": "job_role_q",
+            "question_name": "job_role",
+            "question_text": "What is your job role?",
+            "response_type": "text",
+            "response_options": [],
+            "response_name": "job-role",
+            "used_for_classifications": True,
+            "placeholder_field": "job_title",
         }
-        session.modified = True
 
-        response = update_session_and_redirect(
-            req=Request.from_values(data={"job-role": "Engineer"}),
-            questions=[test_question],
-            survey_assist=survey_assist,
-            value="job-role",
-            route="survey.survey",
-        )
+        with app.test_request_context(method="POST", data={"job-role": "Engineer"}):
+            interactions = [{"after_question_id": "job_role_q"}]
+            survey_assist = {"enabled": True, "interactions": interactions}
+            # Prepare the session for the correct branching
+            session["current_question_index"] = 0
+            session["response"] = {"job_title": "Engineer"}
 
-        assert response.status_code == HTTPStatus.FOUND
-        assert response.location.endswith(url_for("survey.survey_assist_consent"))
+            # Disable duplicate code check as the test needs to match the intent
+            # pylint: disable=R0801
+            session["survey_iteration"] = {
+                "user": "",
+                "questions": [],
+                "time_start": None,
+                "time_end": None,
+                "survey_assist_time_start": None,
+                "survey_assist_time_end": None,
+            }
+            session.modified = True
+
+            response = update_session_and_redirect(
+                req=Request.from_values(data={"job-role": "Engineer"}),
+                questions=[test_question],
+                survey_assist=survey_assist,
+                value="job-role",
+                route="survey.survey",
+            )
+
+            assert response.status_code == HTTPStatus.FOUND
+            assert response.location.endswith(url_for("survey.survey_assist_consent"))
 
 
 @pytest.mark.utils

--- a/utils/app_types.py
+++ b/utils/app_types.py
@@ -25,6 +25,7 @@ class SurveyAssistFlask(Flask):
         sa_email (str): Survey Assist service account.
         survey_title (str): Title of the survey.
         survey_intro (bool): Is survey intro enabled or not.
+        show_consent (bool): Should the consent be shown before Survey Assist questions.
         survey_assist (dict[str, Any]): Survey Assist configuration dictionary.
         token_start_time (int): Start time for the authentication token.
         questions (list[dict[str, Any]]): List of survey question dictionaries.
@@ -37,6 +38,7 @@ class SurveyAssistFlask(Flask):
     sa_email: str
     survey_title: str
     survey_intro: bool
+    show_consent: bool
     survey_assist: dict[str, Any]
     token_start_time: int
     questions: list[dict[str, Any]]

--- a/utils/app_utils.py
+++ b/utils/app_utils.py
@@ -1,0 +1,47 @@
+"""Flask application utility functions.
+
+This module provides helper functions setting up the Flask application.
+"""
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+def load_survey_definition(flask_app: Any, file_path: str | Path) -> None:
+    """Load survey definition from JSON and set attributes on the Flask app.
+
+    Args:
+        flask_app: The Flask app instance.
+        file_path: Path to the survey definition JSON file.
+
+    Raises:
+        FileNotFoundError
+    """
+    file_path = Path(file_path)
+
+    if not file_path.exists():
+        raise FileNotFoundError(f"Survey definition file not found: {file_path}")
+
+    # Load the survey definition
+    with file_path.open(encoding="utf-8") as file:
+        survey_definition = json.load(file)
+
+    flask_app.survey_title = survey_definition.get(
+        "survey_title", "Survey Assist Example"
+    )
+
+    survey_intro = survey_definition.get("survey_intro", {})
+    if isinstance(survey_intro, dict):
+        flask_app.survey_intro = survey_intro.get("enabled", False)
+    else:
+        flask_app.survey_intro = False
+
+    flask_app.questions = survey_definition["questions"]
+    flask_app.survey_assist = survey_definition["survey_assist"]
+
+    sa_consent = flask_app.survey_assist.get("consent", {})
+    if isinstance(sa_consent, dict):
+        flask_app.show_consent = sa_consent.get("required", False)
+    else:
+        flask_app.show_consent = False

--- a/utils/session_utils.py
+++ b/utils/session_utils.py
@@ -4,7 +4,7 @@ This module provides helper functions for debugging and inspecting the Flask ses
 """
 
 from collections.abc import Callable, Iterable
-from datetime import datetime
+from datetime import datetime, timezone
 from functools import wraps
 from typing import Any, Optional, TypeVar, Union
 
@@ -484,6 +484,8 @@ def _iter_classify_results(
 
     Skips non-classify interactions and non-list responses (e.g., lookups).
 
+    Updates end_time associated with classify interaction.
+
     Args:
         person_response (GenericResponse): The person's response object.
 
@@ -495,6 +497,11 @@ def _iter_classify_results(
             continue
         if not isinstance(interaction.response, list):
             continue
+
+        # Update the end_time associated with the classification
+        # now that the user has answered questions.  The last time
+        # this is accessed will be the time of the final response.
+        interaction.time_end = datetime.now(timezone.utc)
         yield from interaction.response
 
 

--- a/utils/survey_assist_utils.py
+++ b/utils/survey_assist_utils.py
@@ -26,7 +26,6 @@ from utils.session_utils import (
 )
 
 # This is temporary, will be changed to configurable in the future
-SHOW_CONSENT = True  # Whether to show the consent page
 FOLLOW_UP_TYPE = "both"  # Options: open, closed, both
 
 logger = get_logger(__name__)

--- a/utils/survey_utils.py
+++ b/utils/survey_utils.py
@@ -30,7 +30,6 @@ from utils.session_utils import (
 )
 from utils.survey_assist_utils import (
     FOLLOW_UP_TYPE,
-    SHOW_CONSENT,
     add_question_justifcation_guidance,
     format_followup,
     perform_sic_lookup,
@@ -188,11 +187,12 @@ def update_session_and_redirect(
                     perform_classification = False
 
             if perform_classification:
-                if SHOW_CONSENT:
+                app = cast(SurveyAssistFlask, current_app)
+                if app.show_consent:
                     return redirect(url_for("survey.survey_assist_consent"))
                 else:
                     # skip consent screen
-                    logger.debug("Skipping consent screen for Survey Assist")
+                    logger.debug(f"Skipping consent screen - app.show_consent{app.show_consent}")
 
                     survey_iteration["survey_assist_time_start"] = datetime.now(
                         timezone.utc

--- a/utils/survey_utils.py
+++ b/utils/survey_utils.py
@@ -192,7 +192,9 @@ def update_session_and_redirect(
                     return redirect(url_for("survey.survey_assist_consent"))
                 else:
                     # skip consent screen
-                    logger.debug(f"Skipping consent screen - app.show_consent{app.show_consent}")
+                    logger.debug(
+                        f"Skipping consent screen - app.show_consent{app.show_consent}"
+                    )
 
                     survey_iteration["survey_assist_time_start"] = datetime.now(
                         timezone.utc


### PR DESCRIPTION
# 📌 Configurable display of consent screen and cleanup

## ✨ Summary

For initial testing the consent screen will not be shown. This PR allows a consent display to bre driven by a configurable variable in the survey definition.  There is also some minor cleanup performed under this PR.

## 📜 Changes Introduced
**__init__.py** - extract some of the app config to a utility function and setup the show_consent flag.
**survey_definition.json** - default behaviour is that consent is not shown.
**question_template.html** - make the button display a loader to indicate when long running processes (like classify) are in play.
**session_utils.py** - ensure the end_time in the results is updated appropriately for classify results.
**survey_utils.py** - change the literal to present consent based on the show_consent flag.

Tests are updated 


- [x] Feature implementation (feat:) / bug fix (fix:) / refactoring (chore:) / documentation (docs:) / testing (test:)
- [x] Updates to tests and/or documentation
- n/a Terraform changes (if applicable)

## ✅ Checklist

- [x] Code is formatted using **Black**
- [x] Imports are sorted using **isort**
- [x] Code passes linting with **Ruff**, **Pylint**, and **Mypy**
- [x] Security checks pass using **Bandit**
- [x] Tests are written and pass using **pytest**
- n/a Terraform files (if applicable) follow best practices and have been validated (`terraform fmt` & `terraform validate`)
- [x] DocStrings follow Google-style and are added as per Pylint recommendations
- [x] Documentation has been updated if needed

## 🔍 How to Test

The code is deployed to a sandbox env in GCP. 

Run unit tests:
```bash
make all-tests
```

Test locally:
You need to have logged in to gcloud and set the correct project:

```bash
gcloud auth login
gcloud config set project <sandbox>
```

You need to have authenticated for adc and ensure the quota project is correct:

```bash
gcloud auth application-default login
gcloud auth application-default set-quota-project <sandbox>
```
 
You need to have the following environment variables set:

```bash 
export SA_EMAIL=backend-api-access@<gcp env>
export BACKEND_API_URL=https://survey-assist-api-gw-.../
export BACKEND_API_VERSION = v1
```

The default behaviour of the survey definition file is to skip showing the consent screen before asking dynamic questions.

```bash
make run-ui
```

Verify that the consent screen is NOT shown after the Organisation description question is asked.

Update the survey_definition.json file to have:

```json
"survey_assist": {
  "consent": {
  ...
  "required": true,
  ...
  }
...
}
```

Run the ui:

```bash
make run-ui
```

Verify that a consent screen is shown before asking dynamic questions.
  
