### PR TITLE
fix(ui): Save code and code_division to results

### DIFF
--- a/models/result.py
+++ b/models/result.py
@@ -130,12 +130,16 @@ class LookupResponse(BaseModel):
 
     Attributes:
         found (bool): Whether matches were found.
+        code (str): The matched code.
+        code_division (str): The matched code division.
         potential_codes_count (int): Number of potential codes found.
         potential_divisions (list[PotentialDivision]): List of potential divisions.
         potential_codes (list[PotentialCode]): List of potential codes.
     """
 
     found: bool = Field(..., description="Whether matches were found")
+    code: Optional[str] = Field(None, description="The matched code")
+    code_division: Optional[str] = Field(None, description="The code division")
     potential_codes_count: int = Field(
         ..., description="Number of potential codes found"
     )

--- a/models/result_sic_only.py
+++ b/models/result_sic_only.py
@@ -86,6 +86,8 @@ class LookupResponse(BaseModel):
     """Model for lookup response."""
 
     found: bool = Field(..., description="Whether matches were found")
+    code: Optional[str] = Field(None, description="The matched code")
+    code_division: Optional[str] = Field(None, description="The code division")
     potential_codes_count: int = Field(
         ..., description="Number of potential codes found"
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "survey-assist-ui"
-version = "0.1.0a6"
+version = "0.1.0a7"
 description = "User Interface for Survey Assist API and Backend"
 authors = ["Steve Gibbard <steve.gibbard@ons.gov.uk>"]
 license = "MIT"

--- a/tests/test_session_utils.py
+++ b/tests/test_session_utils.py
@@ -322,7 +322,7 @@ def nested_survey_result_model() -> GenericSurveyAssistResult:
                         response=LookupResponse(
                             found=False,
                             code="",
-                            code_division="",
+                            code_division=None,
                             potential_codes_count=0,
                             potential_divisions=[],
                             potential_codes=[],

--- a/tests/test_session_utils.py
+++ b/tests/test_session_utils.py
@@ -321,6 +321,8 @@ def nested_survey_result_model() -> GenericSurveyAssistResult:
                         ],
                         response=LookupResponse(
                             found=False,
+                            code="",
+                            code_division="",
                             potential_codes_count=0,
                             potential_divisions=[],
                             potential_codes=[],
@@ -491,6 +493,8 @@ def example_interaction() -> GenericSurveyAssistInteraction:
         input=[],
         response=LookupResponse(
             found=True,
+            code="54321",
+            code_division="54",
             potential_codes_count=0,
             potential_codes=[],
             potential_divisions=[],
@@ -873,7 +877,12 @@ def test_add_follow_up_wrong_type_response(
     base_result_with_classify_model.responses[0].survey_assist_interactions[
         0
     ].response = LookupResponse(
-        found=True, potential_codes_count=0, potential_codes=[], potential_divisions=[]
+        found=True,
+        code="54321",
+        code_division="54",
+        potential_codes_count=0,
+        potential_codes=[],
+        potential_divisions=[],
     )
 
     with app.test_request_context():

--- a/utils/api_utils.py
+++ b/utils/api_utils.py
@@ -234,8 +234,8 @@ def map_to_lookup_response(
     """
     found = data.get("code") is not None
 
-    code = data.get("code", "")
-    code_division = data.get("code_division", "")
+    code = data.get("code")
+    code_division = data.get("code_division")
 
     codes = data.get("potential_matches", {}).get("codes") or []
     codes_count = data.get("potential_matches", {}).get("codes_count") or 0

--- a/utils/api_utils.py
+++ b/utils/api_utils.py
@@ -234,6 +234,9 @@ def map_to_lookup_response(
     """
     found = data.get("code") is not None
 
+    code = data.get("code", "")
+    code_division = data.get("code_division", "")
+
     codes = data.get("potential_matches", {}).get("codes") or []
     codes_count = data.get("potential_matches", {}).get("codes_count") or 0
     divisions = data.get("potential_matches", {}).get("divisions") or []
@@ -265,6 +268,8 @@ def map_to_lookup_response(
 
     return LookupResponse(
         found=found,
+        code=code,
+        code_division=code_division,
         potential_codes_count=len(potential_codes),
         potential_codes=potential_codes,
         potential_divisions=potential_divisions,

--- a/utils/map_results_utils.py
+++ b/utils/map_results_utils.py
@@ -108,8 +108,8 @@ def _map_lookup_response(resp: dict[str, Any]) -> LookupResponse:
     """
     return LookupResponse(
         found=bool(resp["found"]),
-        code=resp.get("code", ""),
-        code_division=resp.get("code_division", ""),
+        code=resp.get("code"),
+        code_division=resp.get("code_division"),
         potential_codes_count=int(resp.get("potential_codes_count", 0)),
         potential_divisions=[
             PotentialDivision(

--- a/utils/map_results_utils.py
+++ b/utils/map_results_utils.py
@@ -108,6 +108,8 @@ def _map_lookup_response(resp: dict[str, Any]) -> LookupResponse:
     """
     return LookupResponse(
         found=bool(resp["found"]),
+        code=resp.get("code", ""),
+        code_division=resp.get("code_division", ""),
         potential_codes_count=int(resp.get("potential_codes_count", 0)),
         potential_divisions=[
             PotentialDivision(


### PR DESCRIPTION
# 📌 Save code and code_division

## ✨ Summary

The api added supported for saving the lookup cod and division as part of the results endpoint in [PR26](https://github.com/ONSdigital/survey-assist-api/pull/26), this update adds the values from the UI when the results endpoint is called. 

## 📜 Changes Introduced

**result.py and result_sic_only.py** - Updated to include the new fields
**api_utils.py and map_results_utils.py** - Updated to store the values in session and then use the values when mapping to the result payload.

Tests are updated

- [x] bug fix (fix:)
- [x] Updates to tests and/or documentation
- [x] Terraform changes (if applicable)

## ✅ Checklist

- [x] Code is formatted using **Black**
- [x] Imports are sorted using **isort**
- [x] Code passes linting with **Ruff**, **Pylint**, and **Mypy**
- [x] Security checks pass using **Bandit**
- [x] Tests are written and pass using **pytest**
- n/a Terraform files (if applicable) follow best practices and have been validated (`terraform fmt` & `terraform validate`)
- [x] DocStrings follow Google-style and are added as per Pylint recommendations
- [x] Documentation has been updated if needed

## 🔍 How to Test
Run unit tests:

```bash
make run-all
```

The code is available in the UI deployed to the sandbox GCP environment.

Assuming the API is deployed with example data set.

Run through the questions and answer "pubs" to the Describe your organisation" question.

The survey should find a match when performing a lookup and prompt you to select the type of organisation you work for.

Complete the rest of the survey until you reach the homepage.

In the appropriate GCP bucket, the results for the iteration will show the code was found and the two digit division is populated:
<img width="435" height="548" alt="image" src="https://github.com/user-attachments/assets/0fe6e369-8d97-4267-8a94-2cd5c5fa9365" />

Re-run the above test but instead of "pubs" use a description that will not be found e.g "airport compay" in the organisation description question.

The survey should not find a match and will ask dynamic questions.

Complete the rest of the survey until you reach the homepage.

In the appropriate GCP bucket, the results for the iteration will show the code as not found and the division will be null:
<img width="556" height="520" alt="image" src="https://github.com/user-attachments/assets/a55cb850-0458-4ca5-ac71-c1aaa9384da6" />

 
