### PR TITLE
Sa 336 access control

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,4 +243,3 @@ poetry run python scripts/run_api.py --type sic --action verify-otp --id_str=<ID
 ```bash
 poetry run python scripts/run_api.py --type sic --action delete-otp --id_str=<ID>
 ```
-

--- a/README.md
+++ b/README.md
@@ -67,6 +67,12 @@ To direct standard error and sys to a log file run use the following command.
 make run-ui > application_output.log 2>&1
 ```
 
+#### UI Access Credentials
+
+The UI will be accessed using a unique ID and access code.  These credentials are generated using a separate verification service (see [firestore-otp](https://github.com/ONSdigital/firestore-otp)).
+
+It is assumed such a service is running and you have access to a list of ID and code pairs.  See the environment section for details on how to setup the base url for this service.
+
 #### Run the Application in a Container
 
 To run the application in a container against API gateway deployed in GCP then you can do the following:
@@ -177,6 +183,12 @@ export BACKEND_API_VERSION=v1 (or desired version)
 export SA_EMAIL=<service account email associated with API access>
 ```
 
+The following environment variable is set to connect with the verification service.
+
+```bash
+export VERIFY_API_URL=<URL for cloud run where firestore otp verification service is running>
+```
+
 Set the following environment variables for extra logging of session data and to prettify JSON.
 
 ```bash
@@ -213,3 +225,22 @@ poetry run python scripts/run_api.py --type sic --action classify
 ```bash
 poetry run python scripts/run_api.py --type sic --action both
 ```
+
+#### Execute Verify API root "/"
+
+```bash
+poetry run python scripts/run_api.py --type sic --action root-otp
+```
+
+#### Execute Verify API Post /verify
+
+```bash
+poetry run python scripts/run_api.py --type sic --action verify-otp --id_str=<ID> --otp=EXAM-PLE1-23FO-UR56
+```
+
+#### Execute Verify API Post /delete
+
+```bash
+poetry run python scripts/run_api.py --type sic --action delete-otp --id_str=<ID>
+```
+

--- a/cicd/cloudbuild_dev_and_sandbox.yaml
+++ b/cicd/cloudbuild_dev_and_sandbox.yaml
@@ -16,7 +16,7 @@ steps:
       - '-c'
       - >
         export BACKEND_API_URL=$_BACKEND_API_URL export BACKEND_API_VERSION=v1
-        export SA_EMAIL=$_SA_EMAIL
+        export SA_EMAIL=$_SA_EMAIL export VERIFY_API_URL=$_VERIFY_API_URL
 
         poetry install
 

--- a/models/result_sic_only.py
+++ b/models/result_sic_only.py
@@ -58,8 +58,8 @@ class ClassificationResponse(BaseModel):
     """Model for classification response."""
 
     classified: bool = Field(..., description="Whether the input was classified")
-    code: str = Field(..., description="The classification code")
-    description: str = Field(..., description="The classification description")
+    code: Optional[str] = Field(None, description="The classification code")
+    description: Optional[str] = Field(None, description="The classification description")
     reasoning: str = Field(..., description="Reasoning behind the classification")
     candidates: list[Candidate] = Field(
         ..., description="List of potential classifications"

--- a/models/result_sic_only.py
+++ b/models/result_sic_only.py
@@ -59,7 +59,9 @@ class ClassificationResponse(BaseModel):
 
     classified: bool = Field(..., description="Whether the input was classified")
     code: Optional[str] = Field(None, description="The classification code")
-    description: Optional[str] = Field(None, description="The classification description")
+    description: Optional[str] = Field(
+        None, description="The classification description"
+    )
     reasoning: str = Field(..., description="Reasoning behind the classification")
     candidates: list[Candidate] = Field(
         ..., description="List of potential classifications"

--- a/poetry.lock
+++ b/poetry.lock
@@ -824,24 +824,25 @@ testing = ["covdefaults (>=2.3)", "coverage (>=7.6.10)", "diff-cover (>=9.2.1)",
 typing = ["typing-extensions (>=4.12.2) ; python_version < \"3.11\""]
 
 [[package]]
-name = "firestore-otp-api-client"
+name = "firestore-otp-verification-api-client"
 version = "0.1.0"
-description = "Typed Python client for the Firestore OTP FastAPI service."
+description = "Firestore OTP API"
 optional = false
-python-versions = ">=3.12,<4.0"
+python-versions = "*"
 groups = ["main"]
 files = [
-    {file = "firestore_otp_api_client-0.1.0-py3-none-any.whl", hash = "sha256:758d2d069dd905b3f355e492d41ebc627c52836ef8bf7ed809af0a8bbf3dcba7"},
+    {file = "firestore_otp_verification_api_client-0.1.0-py3-none-any.whl", hash = "sha256:08977dcd60d18ccd193633d5ca14d8c319d0ee72345c8d058f73d3a4a01074f8"},
 ]
 
 [package.dependencies]
-httpx = ">=0.27.2,<0.28.0"
-pydantic = ">=2.8.0,<3.0.0"
-typing-extensions = ">=4.12.2,<5.0.0"
+pydantic = ">=2"
+python-dateutil = ">=2.8.2"
+typing-extensions = ">=4.7.1"
+urllib3 = ">=2.1.0,<3.0.0"
 
 [package.source]
 type = "file"
-url = "../firestore-otp-api-client/dist/firestore_otp_api_client-0.1.0-py3-none-any.whl"
+url = "../firestore-otp-verification-api-client/dist/firestore_otp_verification_api_client-0.1.0-py3-none-any.whl"
 
 [[package]]
 name = "flask"
@@ -1717,66 +1718,6 @@ gevent = ["gevent (>=1.4.0)"]
 setproctitle = ["setproctitle"]
 testing = ["coverage", "eventlet", "gevent", "pytest", "pytest-cov"]
 tornado = ["tornado (>=0.2)"]
-
-[[package]]
-name = "h11"
-version = "0.16.0"
-description = "A pure-Python, bring-your-own-I/O implementation of HTTP/1.1"
-optional = false
-python-versions = ">=3.8"
-groups = ["main"]
-files = [
-    {file = "h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86"},
-    {file = "h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1"},
-]
-
-[[package]]
-name = "httpcore"
-version = "1.0.9"
-description = "A minimal low-level HTTP client."
-optional = false
-python-versions = ">=3.8"
-groups = ["main"]
-files = [
-    {file = "httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55"},
-    {file = "httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8"},
-]
-
-[package.dependencies]
-certifi = "*"
-h11 = ">=0.16"
-
-[package.extras]
-asyncio = ["anyio (>=4.0,<5.0)"]
-http2 = ["h2 (>=3,<5)"]
-socks = ["socksio (==1.*)"]
-trio = ["trio (>=0.22.0,<1.0)"]
-
-[[package]]
-name = "httpx"
-version = "0.27.2"
-description = "The next generation HTTP client."
-optional = false
-python-versions = ">=3.8"
-groups = ["main"]
-files = [
-    {file = "httpx-0.27.2-py3-none-any.whl", hash = "sha256:7bb2708e112d8fdd7829cd4243970f0c223274051cb35ee80c03301ee29a3df0"},
-    {file = "httpx-0.27.2.tar.gz", hash = "sha256:f7c2be1d2f3c3c3160d441802406b206c2b76f5947b11115e6df10c6c65e66c2"},
-]
-
-[package.dependencies]
-anyio = "*"
-certifi = "*"
-httpcore = "==1.*"
-idna = "*"
-sniffio = "*"
-
-[package.extras]
-brotli = ["brotli ; platform_python_implementation == \"CPython\"", "brotlicffi ; platform_python_implementation != \"CPython\""]
-cli = ["click (==8.*)", "pygments (==2.*)", "rich (>=10,<14)"]
-http2 = ["h2 (>=3,<5)"]
-socks = ["socksio (==1.*)"]
-zstd = ["zstandard (>=0.18.0)"]
 
 [[package]]
 name = "identify"
@@ -4368,4 +4309,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12"
-content-hash = "8545c5832798c5becc889580b0f24bd00900987b473fff6e900a9edc2137645b"
+content-hash = "00f8830c2a7083a438c43596045f7b04feda8003f0d18642ea43eb45c1c77ca9"

--- a/poetry.lock
+++ b/poetry.lock
@@ -824,6 +824,26 @@ testing = ["covdefaults (>=2.3)", "coverage (>=7.6.10)", "diff-cover (>=9.2.1)",
 typing = ["typing-extensions (>=4.12.2) ; python_version < \"3.11\""]
 
 [[package]]
+name = "firestore-otp-api-client"
+version = "0.1.0"
+description = "Typed Python client for the Firestore OTP FastAPI service."
+optional = false
+python-versions = ">=3.12,<4.0"
+groups = ["main"]
+files = [
+    {file = "firestore_otp_api_client-0.1.0-py3-none-any.whl", hash = "sha256:758d2d069dd905b3f355e492d41ebc627c52836ef8bf7ed809af0a8bbf3dcba7"},
+]
+
+[package.dependencies]
+httpx = ">=0.27.2,<0.28.0"
+pydantic = ">=2.8.0,<3.0.0"
+typing-extensions = ">=4.12.2,<5.0.0"
+
+[package.source]
+type = "file"
+url = "../firestore-otp-api-client/dist/firestore_otp_api_client-0.1.0-py3-none-any.whl"
+
+[[package]]
 name = "flask"
 version = "3.1.1"
 description = "A simple framework for building complex web applications."
@@ -1697,6 +1717,66 @@ gevent = ["gevent (>=1.4.0)"]
 setproctitle = ["setproctitle"]
 testing = ["coverage", "eventlet", "gevent", "pytest", "pytest-cov"]
 tornado = ["tornado (>=0.2)"]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+description = "A pure-Python, bring-your-own-I/O implementation of HTTP/1.1"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86"},
+    {file = "h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1"},
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+description = "A minimal low-level HTTP client."
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55"},
+    {file = "httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8"},
+]
+
+[package.dependencies]
+certifi = "*"
+h11 = ">=0.16"
+
+[package.extras]
+asyncio = ["anyio (>=4.0,<5.0)"]
+http2 = ["h2 (>=3,<5)"]
+socks = ["socksio (==1.*)"]
+trio = ["trio (>=0.22.0,<1.0)"]
+
+[[package]]
+name = "httpx"
+version = "0.27.2"
+description = "The next generation HTTP client."
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "httpx-0.27.2-py3-none-any.whl", hash = "sha256:7bb2708e112d8fdd7829cd4243970f0c223274051cb35ee80c03301ee29a3df0"},
+    {file = "httpx-0.27.2.tar.gz", hash = "sha256:f7c2be1d2f3c3c3160d441802406b206c2b76f5947b11115e6df10c6c65e66c2"},
+]
+
+[package.dependencies]
+anyio = "*"
+certifi = "*"
+httpcore = "==1.*"
+idna = "*"
+sniffio = "*"
+
+[package.extras]
+brotli = ["brotli ; platform_python_implementation == \"CPython\"", "brotlicffi ; platform_python_implementation != \"CPython\""]
+cli = ["click (==8.*)", "pygments (==2.*)", "rich (>=10,<14)"]
+http2 = ["h2 (>=3,<5)"]
+socks = ["socksio (==1.*)"]
+zstd = ["zstandard (>=0.18.0)"]
 
 [[package]]
 name = "identify"
@@ -4288,4 +4368,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12"
-content-hash = "3c6269c6c9da0b77b93ee2b39650b534b2fcf6fe72ea8199a7b83304a5d9d712"
+content-hash = "8545c5832798c5becc889580b0f24bd00900987b473fff6e900a9edc2137645b"

--- a/poetry.lock
+++ b/poetry.lock
@@ -828,21 +828,22 @@ name = "firestore-otp-verification-api-client"
 version = "0.1.0"
 description = "Firestore OTP API"
 optional = false
-python-versions = "*"
+python-versions = "^3.9"
 groups = ["main"]
-files = [
-    {file = "firestore_otp_verification_api_client-0.1.0-py3-none-any.whl", hash = "sha256:08977dcd60d18ccd193633d5ca14d8c319d0ee72345c8d058f73d3a4a01074f8"},
-]
+files = []
+develop = false
 
 [package.dependencies]
-pydantic = ">=2"
-python-dateutil = ">=2.8.2"
-typing-extensions = ">=4.7.1"
-urllib3 = ">=2.1.0,<3.0.0"
+pydantic = ">= 2"
+python-dateutil = ">= 2.8.2"
+typing-extensions = ">= 4.7.1"
+urllib3 = ">= 2.1.0, < 3.0.0"
 
 [package.source]
-type = "file"
-url = "../firestore-otp-verification-api-client/dist/firestore_otp_verification_api_client-0.1.0-py3-none-any.whl"
+type = "git"
+url = "https://github.com/ONSdigital/firestore-otp-verification-api-client.git"
+reference = "v0.1.0"
+resolved_reference = "c0929be98241d85afbef56722521d229a974058b"
 
 [[package]]
 name = "flask"
@@ -4309,4 +4310,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12"
-content-hash = "00f8830c2a7083a438c43596045f7b04feda8003f0d18642ea43eb45c1c77ca9"
+content-hash = "ecac122d5fff55da95908248fca31f5466c83edf568ec95afbfdfa6cb388a7b2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "survey-assist-ui"
-version = "0.1.0a10"
+version = "0.1.0a11"
 description = "User Interface for Survey Assist API and Backend"
 authors = ["Steve Gibbard <steve.gibbard@ons.gov.uk>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ flask-misaka = "^1.0.1"
 survey-assist-utils = { git = "https://github.com/ONSdigital/survey-assist-utils.git", tag = "v0.0.3" }
 pydantic = "^2.11.7"
 gunicorn = "^23.0.0"
-firestore-otp-verification-api-client = {path = "../firestore-otp-verification-api-client/dist/firestore_otp_verification_api_client-0.1.0-py3-none-any.whl"}
+firestore-otp-verification-api-client = {git = "https://github.com/ONSdigital/firestore-otp-verification-api-client.git", tag = "v0.1.0"}
 
 [tool.poetry.group.dev.dependencies]
 mkdocs-material = "^9.6.7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ flask-misaka = "^1.0.1"
 survey-assist-utils = { git = "https://github.com/ONSdigital/survey-assist-utils.git", tag = "v0.0.3" }
 pydantic = "^2.11.7"
 gunicorn = "^23.0.0"
-firestore-otp-api-client = {path = "../firestore-otp-api-client/dist/firestore_otp_api_client-0.1.0-py3-none-any.whl"}
+firestore-otp-verification-api-client = {path = "../firestore-otp-verification-api-client/dist/firestore_otp_verification_api_client-0.1.0-py3-none-any.whl"}
 
 [tool.poetry.group.dev.dependencies]
 mkdocs-material = "^9.6.7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ flask-misaka = "^1.0.1"
 survey-assist-utils = { git = "https://github.com/ONSdigital/survey-assist-utils.git", tag = "v0.0.3" }
 pydantic = "^2.11.7"
 gunicorn = "^23.0.0"
+firestore-otp-api-client = {path = "../firestore-otp-api-client/dist/firestore_otp_api_client-0.1.0-py3-none-any.whl"}
 
 [tool.poetry.group.dev.dependencies]
 mkdocs-material = "^9.6.7"

--- a/scripts/run_api.py
+++ b/scripts/run_api.py
@@ -11,7 +11,6 @@ import argparse
 import json
 import os
 import re
-import subprocess
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
@@ -48,7 +47,7 @@ from models.result_sic_only import (
     SurveyAssistInteraction,
     SurveyAssistResult,
 )
-from utils.api_utils import APIClient  # pylint: disable=wrong-import-position
+from utils.api_utils import APIClient, get_verification_api_id_token  # pylint: disable=wrong-import-position
 from utils.feedback_utils import FeedbackSession, feedback_session_to_model
 from utils.map_results_utils import (
     translate_session_to_model,
@@ -63,15 +62,6 @@ VERIFY_API_URL = os.getenv("VERIFY_API_URL", "http://0.0.0.0:8080")
 verify_api_configuration = firestore_otp_verification_api_client.Configuration(
     host=VERIFY_API_URL
 )
-
-
-def get_verification_api_id_token():
-    """Generate a Google ID token for the firestore-otp-api."""
-    gcloud_print_id_token = subprocess.check_output(  # noqa: S603
-        ["gcloud", "auth", "print-identity-token"]  # noqa: S607
-    )
-    id_token = gcloud_print_id_token.decode().strip()
-    return id_token
 
 
 def parse_z(ts: str) -> datetime:

--- a/scripts/run_api.py
+++ b/scripts/run_api.py
@@ -640,7 +640,7 @@ def main() -> None:  # noqa: C901, PLR0912, PLR0915, PLR0911
             )
 
             try:
-                token = get_verification_api_id_token()
+                token = get_verification_api_id_token(audience=VERIFY_API_URL)
 
                 # Health Check & Config Info
                 api_response: HealthConfigResponse = api_instance.root_get(
@@ -657,7 +657,7 @@ def main() -> None:  # noqa: C901, PLR0912, PLR0915, PLR0911
         if not args.id_str:
             parser.error("--id_str is required when --action delete-otp")
 
-        token = get_verification_api_id_token()
+        token = get_verification_api_id_token(audience=VERIFY_API_URL)
         logger.debug(f"id:{args.id_str}")
 
         verify_client = APIClient(
@@ -677,7 +677,7 @@ def main() -> None:  # noqa: C901, PLR0912, PLR0915, PLR0911
         if not args.otp or not args.id_str:
             parser.error("--otp and --id_str are required when --action verify-otp")
 
-        token = get_verification_api_id_token()
+        token = get_verification_api_id_token(audience=VERIFY_API_URL)
         logger.debug(f"id:{args.id_str} otp:{args.otp}")
 
         verify_client = APIClient(
@@ -693,7 +693,7 @@ def main() -> None:  # noqa: C901, PLR0912, PLR0915, PLR0911
         return
 
     if args.action == "verify-invalid-otp":
-        token = get_verification_api_id_token()
+        token = get_verification_api_id_token(audience=VERIFY_API_URL)
         logger.debug(f"id:{args.id_str} otp:{args.otp}")
 
         verify_client = APIClient(

--- a/scripts/run_api.py
+++ b/scripts/run_api.py
@@ -47,7 +47,10 @@ from models.result_sic_only import (
     SurveyAssistInteraction,
     SurveyAssistResult,
 )
-from utils.api_utils import APIClient, get_verification_api_id_token  # pylint: disable=wrong-import-position
+from utils.api_utils import (  # pylint: disable=wrong-import-position
+    APIClient,
+    get_verification_api_id_token,
+)
 from utils.feedback_utils import FeedbackSession, feedback_session_to_model
 from utils.map_results_utils import (
     translate_session_to_model,

--- a/survey_assist_ui/__init__.py
+++ b/survey_assist_ui/__init__.py
@@ -17,6 +17,7 @@ from survey_assist_utils.api_token.jwt_utils import check_and_refresh_token
 from survey_assist_utils.logging import get_logger
 
 from survey_assist_ui.routes import register_blueprints
+from utils.access_utils import update_tokens_on_api_clients
 from utils.api_utils import APIClient, get_verification_api_id_token
 from utils.app_types import SurveyAssistFlask
 from utils.app_utils import load_survey_definition
@@ -52,7 +53,9 @@ def create_app(test_config: dict | None = None) -> SurveyAssistFlask:
     flask_app.token_start_time = 0
 
     # Get a token for the verify service
-    flask_app.verify_api_token = get_verification_api_id_token()
+    flask_app.verify_api_token = get_verification_api_id_token(
+        os.getenv("VERIFY_API_URL", "http://127.0.0.1:8080")
+    )
 
     Misaka(flask_app)
 
@@ -133,10 +136,9 @@ def create_app(test_config: dict | None = None) -> SurveyAssistFlask:
             app.sa_email,
         )
 
+        # Update the client when a new token is generated
         if orig_time != app.token_start_time:
-            logger.info(
-                f"JWT token refresh Rx Method: {request.method} - Route: {request.endpoint}"
-            )
+            update_tokens_on_api_clients(flask_app, request, app.api_token)
 
     @flask_app.after_request
     def add_version_header(resp):

--- a/survey_assist_ui/__init__.py
+++ b/survey_assist_ui/__init__.py
@@ -12,6 +12,7 @@ from urllib.parse import urlparse
 
 from flask import request
 from flask_misaka import Misaka
+from jinja2 import ChainableUndefined
 from survey_assist_utils.api_token.jwt_utils import check_and_refresh_token
 from survey_assist_utils.logging import get_logger
 
@@ -38,6 +39,8 @@ def create_app(test_config: dict | None = None) -> SurveyAssistFlask:
         SurveyAssistFlask: The initialised and configured Flask application instance.
     """
     flask_app = SurveyAssistFlask(__name__)
+    # ONS macros assume ChainableUndefined (e.g if a parameter is missing assume false)
+    flask_app.jinja_env.undefined = ChainableUndefined
     flask_app.secret_key = os.getenv("FLASK_SECRET_KEY", os.urandom(24))
     flask_app.sa_email = os.getenv("SA_EMAIL", "SA_EMAIL_NOT_SET")
     flask_app.api_base = os.getenv("BACKEND_API_URL", "http://127.0.0.1:5000")

--- a/survey_assist_ui/routes/__init__.py
+++ b/survey_assist_ui/routes/__init__.py
@@ -4,6 +4,7 @@ This module imports and provides a function to register all route blueprints
 with a Flask application instance.
 """
 
+from .access import access_blueprint
 from .error import error_blueprint
 from .feedback import feedback_blueprint
 from .index import main_blueprint
@@ -21,6 +22,7 @@ def register_blueprints(app):
     Returns:
         None
     """
+    app.register_blueprint(access_blueprint)
     app.register_blueprint(main_blueprint)
     app.register_blueprint(survey_blueprint)
     app.register_blueprint(survey_assist_blueprint)

--- a/survey_assist_ui/routes/access.py
+++ b/survey_assist_ui/routes/access.py
@@ -1,0 +1,42 @@
+"""Access and login routes for the Survey Assist UI.
+
+Verifies that the user has a valid code for access to the survey.
+"""
+
+from flask import Blueprint, redirect, render_template, request, session
+from survey_assist_utils.logging import get_logger
+
+from utils.access_utils import validate_access
+from utils.session_utils import session_debug
+
+access_blueprint = Blueprint("access", __name__)
+
+logger = get_logger(__name__, "DEBUG")
+
+
+@access_blueprint.route("/access", methods=["GET"])
+@session_debug
+def access():
+    """Renders the access page.
+
+    Returns:
+        tuple: Rendered HTML for access page.
+    """
+    return render_template("access.html")
+
+
+@access_blueprint.route("/check_access", methods=["POST"])
+def check_access():
+    # Get email and convert to lowercase
+    access_id = request.form.get("email-username").lower()
+    access_otp = request.form.get("password")
+
+    if validate_access(access_id, access_otp):
+        session["access_id"] = access_id
+        session.modified = True
+        logger.info(f"id: {access_id} successfully accessed survey")
+        return redirect("/")
+    else:
+        return render_template(
+            "access.html", error="Invalid credentials. Please try again."
+        )

--- a/survey_assist_ui/routes/access.py
+++ b/survey_assist_ui/routes/access.py
@@ -3,10 +3,13 @@
 Verifies that the user has a valid code for access to the survey.
 """
 
-from flask import Blueprint, redirect, render_template, request, session
+from typing import cast
+
+from flask import Blueprint, current_app, redirect, render_template, request, session
 from survey_assist_utils.logging import get_logger
 
-from utils.access_utils import validate_access
+from utils.access_utils import format_access_code, validate_access
+from utils.app_types import SurveyAssistFlask
 from utils.session_utils import session_debug
 
 access_blueprint = Blueprint("access", __name__)
@@ -22,21 +25,37 @@ def access():
     Returns:
         tuple: Rendered HTML for access page.
     """
-    return render_template("access.html")
+    app = cast(SurveyAssistFlask, current_app)
+    return render_template("access.html", title=app.survey_title)
 
 
 @access_blueprint.route("/check_access", methods=["POST"])
 def check_access():
-    # Get email and convert to lowercase
-    access_id = request.form.get("email-username").lower()
-    access_otp = request.form.get("password")
+    """Checks participant access credentials and redirects accordingly.
 
-    if validate_access(access_id, access_otp):
-        session["access_id"] = access_id
+    Retrieves the participant ID and access code from the form, formats the access code,
+    and validates the credentials. If valid, stores the participant ID in the session and
+    redirects to the home page. If invalid, re-renders the access page with an error.
+
+    Returns:
+        Response: A redirect to the home page if credentials are valid, otherwise the
+        rendered access page with an error message.
+    """
+    app = cast(SurveyAssistFlask, current_app)
+    participant_id = request.form.get("participant-id")
+    access_code = format_access_code(request.form.get("access-code"))
+
+    logger.debug(f"participant: {participant_id} access code:{access_code}")
+    valid, error = validate_access(participant_id, access_code)
+    if valid:
+        session["participant_id"] = participant_id
+        session["access_code"] = access_code
         session.modified = True
-        logger.info(f"id: {access_id} successfully accessed survey")
+        logger.info(f"id: {participant_id} survey accessed")
         return redirect("/")
     else:
         return render_template(
-            "access.html", error="Invalid credentials. Please try again."
+            "access.html",
+            title=app.survey_title,
+            error=error,
         )

--- a/survey_assist_ui/routes/feedback.py
+++ b/survey_assist_ui/routes/feedback.py
@@ -19,6 +19,7 @@ from flask import (
 )
 from survey_assist_utils.logging import get_logger
 
+from utils.access_utils import require_access
 from utils.app_types import ResponseType, SurveyAssistFlask
 from utils.feedback_utils import (
     FeedbackQuestion,
@@ -33,6 +34,7 @@ from utils.session_utils import FIRST_QUESTION, remove_model_from_session, sessi
 from utils.survey_utils import number_to_word
 
 feedback_blueprint = Blueprint("feedback", __name__)
+feedback_blueprint.before_request(require_access)
 
 logger = get_logger(__name__, level="DEBUG")
 

--- a/survey_assist_ui/routes/feedback.py
+++ b/survey_assist_ui/routes/feedback.py
@@ -30,7 +30,12 @@ from utils.feedback_utils import (
     init_feedback_session,
     send_feedback,
 )
-from utils.session_utils import FIRST_QUESTION, remove_model_from_session, session_debug
+from utils.session_utils import (
+    FIRST_QUESTION,
+    remove_access_from_session,
+    remove_model_from_session,
+    session_debug,
+)
 from utils.survey_utils import number_to_word
 
 feedback_blueprint = Blueprint("feedback", __name__)
@@ -243,6 +248,9 @@ def feedback_thank_you():
         logger.warning("TBD - Error handling. Clean Feedback Session Data")
 
     remove_model_from_session("feedback_response")
+
+    # Remove further access from the session
+    remove_access_from_session()
 
     if "current_feedback_index" in session:
         session["current_feedback_index"] = 0

--- a/survey_assist_ui/routes/index.py
+++ b/survey_assist_ui/routes/index.py
@@ -5,13 +5,16 @@ This is the home page for the Survey Assist UI
 
 from typing import cast
 
-from flask import Blueprint, current_app, render_template, session
+from flask import Blueprint, current_app, redirect, render_template, session
+from flask.typing import ResponseReturnValue
 from survey_assist_utils.logging import get_logger
 
+from utils.access_utils import require_access
 from utils.app_types import SurveyAssistFlask
 from utils.session_utils import remove_model_from_session, session_debug
 
 main_blueprint = Blueprint("main", __name__)
+main_blueprint.before_request(require_access)
 
 logger = get_logger(__name__)
 
@@ -19,7 +22,7 @@ logger = get_logger(__name__)
 # Method to render the index page
 @main_blueprint.route("/")
 @session_debug
-def index() -> str:
+def index() -> ResponseReturnValue:
     """Renders the index page.
 
     This route handles requests to the root URL ("/") and serves the `index.html` template.
@@ -30,6 +33,9 @@ def index() -> str:
     logger.info("Rendering index page")
 
     app = cast(SurveyAssistFlask, current_app)
+
+    if "participant_id" not in session and "access_code" not in session:
+        return redirect("/access")
 
     # Reset the current question index in the session
     if "current_question_index" in session:

--- a/survey_assist_ui/routes/survey.py
+++ b/survey_assist_ui/routes/survey.py
@@ -22,6 +22,7 @@ from models.result import (
     GenericResponse,
     GenericSurveyAssistResult,
 )
+from utils.access_utils import require_access
 from utils.app_types import ResponseType, SurveyAssistFlask
 from utils.map_results_utils import translate_session_to_model
 from utils.session_utils import (
@@ -41,6 +42,8 @@ from utils.survey_utils import (
 )
 
 survey_blueprint = Blueprint("survey", __name__)
+survey_blueprint.before_request(require_access)
+
 
 logger = get_logger(__name__, level="DEBUG")
 

--- a/survey_assist_ui/routes/survey_assist.py
+++ b/survey_assist_ui/routes/survey_assist.py
@@ -9,11 +9,13 @@ from flask import (
 )
 from survey_assist_utils.logging import get_logger
 
+from utils.access_utils import require_access
 from utils.app_types import ResponseType
 from utils.session_utils import session_debug
 from utils.survey_assist_utils import classify_and_handle_followup
 
 survey_assist_blueprint = Blueprint("survey_assist", __name__)
+survey_assist_blueprint.before_request(require_access)
 
 logger = get_logger(__name__, level="DEBUG")
 

--- a/survey_assist_ui/templates/access.html
+++ b/survey_assist_ui/templates/access.html
@@ -1,0 +1,72 @@
+{% extends "layout/_template.njk" %}
+{% from "components/access-code/_macro.njk" import onsAccessCode %}
+{% from "components/button/_macro.njk" import onsButton %}
+{% from "components/panel/_macro.njk" import onsPanel %}
+{% from "components/details/_macro.njk" import onsDetails %}
+{%
+    set pageConfig = {
+        "header": {
+            "title": "Study title",
+            "mastheadLogo": {
+              "large": '<img class="logo" src="https://cdn.ons.gov.uk/assets/images/ons-logo/v2/ons-logo.svg" height="150" width="250" alt="Office for National Statistics logo">'
+            },
+            "titleLogo": "/",
+        },
+        "meta": {
+            "canonicalUrl": "/",
+            "description": "/",
+        },
+        
+    }
+%}
+
+{% block main %}
+    <h1 class="ons-u-mt-2xl">Start study</h1>
+
+    {{
+        onsAccessCode({
+            "id": "access-code-example",
+            "name": "access-code",
+            "postTextboxLinkText": "Where to find your access code",
+            "postTextboxLinkUrl": "#0",
+            "label": {
+                "text": "Enter your 16-character access code",
+                "description": "Keep this code safe. You will need to enter it every time you access your study"
+            },
+            "securityMessage": "Your personal information is protected by law and will be kept confidential"
+        })
+    }}
+
+    {{
+        onsButton({
+            "text": "Access study",
+            "classes": "ons-u-mb-2xl ons-u-mt-s"
+        })
+    }}
+
+    <h2>If you do not have an access code</h2>
+    <p>
+        If you have lost or not received an access code, you can <a href="#0">request a new access code</a>. This can be sent to you by text
+        or post.
+    </p>
+
+    {% set content %}
+        <p>If you need to answer separately from the people you live with, you can <a href="#0">request an individual access code</a>.</p>
+        {%
+            call onsPanel({
+                "variant": "warn"
+            })
+        %}
+            Someone in your household must still complete a study using this household access code
+        {% endcall %}
+    {% endset %}
+
+    {%
+        call onsDetails({
+            "id": "details",
+            "title": "Need to answer separately from your household?"
+        })
+    %}
+        {{ content | safe }}
+    {% endcall %}
+{% endblock %}

--- a/survey_assist_ui/templates/access.html
+++ b/survey_assist_ui/templates/access.html
@@ -1,12 +1,13 @@
 {% extends "layout/_template.njk" %}
 {% from "components/access-code/_macro.njk" import onsAccessCode %}
+{% from "components/input/_macro.njk" import onsInput %}
 {% from "components/button/_macro.njk" import onsButton %}
 {% from "components/panel/_macro.njk" import onsPanel %}
 {% from "components/details/_macro.njk" import onsDetails %}
 {%
     set pageConfig = {
         "header": {
-            "title": "Study title",
+            "title": title,
             "mastheadLogo": {
               "large": '<img class="logo" src="https://cdn.ons.gov.uk/assets/images/ons-logo/v2/ons-logo.svg" height="150" width="250" alt="Office for National Statistics logo">'
             },
@@ -21,19 +22,41 @@
 %}
 
 {% block main %}
+    {% if error %}
+        {%
+            call onsPanel({
+                "title": "There is a problem validating your ONS ID or PFR ID",
+                "variant": "error"
+            })
+        %}
+        {{error}}
+    {% endcall %}
+    {% endif %}
     <h1 class="ons-u-mt-2xl">Start study</h1>
+    <form method="POST" action="{{ url_for('access.check_access') }}"> 
 
     {{
-        onsAccessCode({
-            "id": "access-code-example",
-            "name": "access-code",
-            "postTextboxLinkText": "Where to find your access code",
-            "postTextboxLinkUrl": "#0",
+        onsInput({
+            "id": "unique-participant-id",
+            "name": "participant-id",
+            "type": "number",
             "label": {
-                "text": "Enter your 16-character access code",
-                "description": "Keep this code safe. You will need to enter it every time you access your study"
+                "text": "Enter your ONS Participant ID",
+                "description": "This ID will have been provided to you in the email from PFR."
             },
-            "securityMessage": "Your personal information is protected by law and will be kept confidential"
+            "attributes": { "required": true }
+        })
+    }}
+    {{
+        onsAccessCode({
+            "id": "unique-access-code",
+            "name": "access-code",
+            "label": {
+                "text": "Enter your 16-character PFR ID",
+                "description": "This ID can be found in the email invite PFR sent you. This ID will be used to gain access to the stidy and process your incentive."
+            },
+            "securityMessage": "Your personal information is protected by law and will be kept confidential",
+            "attributes": { "required": true }
         })
     }}
 
@@ -43,6 +66,7 @@
             "classes": "ons-u-mb-2xl ons-u-mt-s"
         })
     }}
+    </form>
 
     <h2>If you do not have an access code</h2>
     <p>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,6 +49,15 @@ def app() -> Flask:
 
 
 @pytest.fixture
+def granted_access(client):
+    """Provides a client with access granted."""
+    with client.session_transaction() as sess:
+        sess["participant_id"] = "1"
+        sess["access_code"] = "EXAM-PLE1-23FO-UR56"
+    return client
+
+
+@pytest.fixture
 def mock_questions() -> list[dict]:
     """Provides a mock survey question set for testing the /survey route."""
     return [

--- a/tests/test_access_utils.py
+++ b/tests/test_access_utils.py
@@ -1,0 +1,121 @@
+"""Tests for the format_access_code utility function."""
+
+import re
+from io import StringIO
+
+import pytest
+
+from utils.access_utils import format_access_code, validate_access
+
+
+@pytest.mark.utils
+class TestFormatAccessCode:
+    """Unit tests for format_access_code."""
+
+    @pytest.mark.parametrize(
+        "raw, expected",
+        [
+            ("abc123", "ABC123"),
+            (" abc123 ", "ABC123"),  # trims whitespace
+            ("\tabc123\t", "ABC123"),  # trims tabs
+            ("abc 123", "ABC-123"),  # converts single space
+            ("abc\t123", "ABC-123"),  # converts tab
+            ("abc   123", "ABC-123"),  # converts multiple spaces
+            (" abc \t 123 ", "ABC-123"),  # mixed whitespace
+            ("a b\tc  d", "A-B-C-D"),  # mixed spacing between letters
+            ("Ex12 8rtY AeFF 33CV", "EX12-8RTY-AEFF-33CV"),  # 16 char example
+            ("", ""),  # empty string
+            ("   ", ""),  # only whitespace
+        ],
+    )
+    def test_valid_access_code_formats(self, raw: str, expected: str) -> None:
+        """It should correctly format and normalise valid access codes.
+
+        Args:
+            raw (str): The unformatted access code.
+            expected (str): The expected formatted code.
+        """
+        result = format_access_code(raw)
+        assert result == expected, f"Expected '{expected}' but got '{result}'"
+
+    def test_returns_uppercase(self) -> None:
+        """It should always return uppercase output."""
+        result = format_access_code("aBcDe fGh")
+        assert result.isupper(), "Access code should be converted to uppercase"
+
+    def test_handles_multiple_internal_whitespace(self) -> None:
+        """It should replace multiple consecutive whitespace sequences with a single hyphen."""
+        result = format_access_code("abc   \t   def")
+        assert result == "ABC-DEF"
+
+    def test_does_not_mutate_input(self) -> None:
+        """It should not modify the input string in place."""
+        raw = "abc 123"
+        original = raw[:]
+        _ = format_access_code(raw)
+        assert raw == original, "Input string should remain unchanged"
+
+    def test_regex_used_for_whitespace_replacement(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """It should call re.sub with the correct whitespace pattern."""
+        spy_called = {}
+
+        def fake_sub(pattern: str, repl: str, text: str) -> str:
+            spy_called.update({"pattern": pattern, "repl": repl, "text": text})
+            return "MOCKED"
+
+        monkeypatch.setattr(re, "sub", fake_sub)
+        result = format_access_code("abc def")
+
+        assert result == "MOCKED"
+        assert spy_called["pattern"] == r"\s+", "Should use regex pattern '\\s+'"
+        assert spy_called["repl"] == "-", "Should replace with a single hyphen"
+        assert spy_called["text"] == "abc def", "Should pass stripped text to re.sub"
+
+
+@pytest.mark.auth
+class TestValidateAccess:
+    """Tests for access validation logic that do not depend on file operations."""
+
+    def test_returns_error_when_access_code_missing(self) -> None:
+        """It should return an error when the access code is missing.
+
+        Verifies the early-return branch for a falsy access_code.
+        """
+        # Act
+        result: tuple[bool, str] = validate_access(access_id="ONS123", access_code="")
+
+        # Assert
+        assert result == (
+            False,
+            "You must enter both ONS ID and PFR ID",
+        ), "Should require both ONS ID and PFR ID"
+
+    def test_returns_error_when_access_not_found(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """It should return an error when no credentials match the provided id/code.
+
+        Patches file existence and provides an empty CSV via StringIO to avoid disk I/O.
+        """
+        # Pretend the credentials file exists
+        monkeypatch.setattr("utils.access_utils.os.path.exists", lambda _path: True)
+
+        # Provide an empty CSV with headers only; no matching rows possible
+        empty_csv = "survey_access_id,one_time_passcode\n"
+        monkeypatch.setattr(
+            "builtins.open", lambda *args, **kwargs: StringIO(empty_csv)
+        )
+
+        # Act
+        result: tuple[bool, str] = validate_access(
+            access_id="NONEXISTENT_ID",
+            access_code="WRONG_CODE",
+        )
+
+        # Assert
+        assert result == (
+            False,
+            "Invalid credentials. Please try again.",
+        ), "Should return invalid credentials when no matching row is found"

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -15,6 +15,23 @@ from utils.session_utils import FIRST_QUESTION
 
 
 @pytest.mark.route
+def test_access_route(client) -> None:
+    """Tests that the access route contains survey title and returns a 200 OK response.
+
+    Args:
+        client: Flask test client fixture.
+    """
+    app = cast(SurveyAssistFlask, current_app)
+    response = client.get("/access")
+    expected_text = app.survey_title
+
+    assert (
+        expected_text.encode() in response.data
+    ), f"Access page should contain '{expected_text}'"
+    assert response.status_code == HTTPStatus.OK, "Access route should return 200 OK"
+
+
+@pytest.mark.route
 def test_index_route(client) -> None:
     """Tests that the index route contains survey title and returns a 200 OK response.
 

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -32,14 +32,14 @@ def test_access_route(client) -> None:
 
 
 @pytest.mark.route
-def test_index_route(client) -> None:
+def test_index_route(granted_access) -> None:
     """Tests that the index route contains survey title and returns a 200 OK response.
 
     Args:
-        client: Flask test client fixture.
+        granted_access: Flask test client fixture.
     """
     app = cast(SurveyAssistFlask, current_app)
-    response = client.get("/")
+    response = granted_access.get("/")
     expected_text = app.survey_title
 
     assert (
@@ -49,14 +49,14 @@ def test_index_route(client) -> None:
 
 
 @pytest.mark.route
-def test_intro_route(client) -> None:
+def test_intro_route(granted_access) -> None:
     """Tests that the survey intro route contains survey title and returns a 200 OK response.
 
     Args:
-        client: Flask test client fixture.
+        granted_access: Flask test client fixture.
     """
     app = cast(SurveyAssistFlask, current_app)
-    response = client.get("/intro")
+    response = granted_access.get("/intro")
     expected_text = app.survey_title
 
     assert (
@@ -85,23 +85,23 @@ def test_error_route(client) -> None:
 
 
 @pytest.mark.route
-def test_first_survey_question(client, mock_questions) -> None:
+def test_first_survey_question(granted_access, mock_questions) -> None:
     """Tests that the survey route contains correct text
     for the first question and returns a 200 OK response.
 
     Args:
-        client: Flask test client fixture.
+        granted_access: Flask test client fixture.
         mock_questions: Mocked questions to simulate survey data.
     """
     app = cast(SurveyAssistFlask, current_app)
 
     with patch.object(app, "questions", mock_questions):
-        with client.session_transaction() as sess:
+        with granted_access.session_transaction() as sess:
             # Ensure a clean state to trigger init logic
             sess.pop("current_question_index", None)
             sess.pop("survey_iteration", None)
 
-        response = client.get("/survey")
+        response = granted_access.get("/survey")
 
         expected_text = mock_questions[0]["question_text"]
         assert (
@@ -113,7 +113,7 @@ def test_first_survey_question(client, mock_questions) -> None:
         ), "Expected 'Save and continue' in response"
 
         # Validate session was initialised correctly
-        with client.session_transaction() as sess:
+        with granted_access.session_transaction() as sess:
             assert "current_question_index" in sess
             assert sess["current_question_index"] == FIRST_QUESTION
             assert "survey_iteration" in sess
@@ -121,23 +121,23 @@ def test_first_survey_question(client, mock_questions) -> None:
 
 
 @pytest.mark.route
-def test_survey_question_justification_disabled(client, mock_questions) -> None:
+def test_survey_question_justification_disabled(granted_access, mock_questions) -> None:
     """Tests that the survey route does not contain a justification,
      the justification_enabled is false and returns a 200 OK response.
 
     Args:
-        client: Flask test client fixture.
+        granted_access: Flask test client fixture.
         mock_questions: Mocked questions to simulate survey data.
     """
     app = cast(SurveyAssistFlask, current_app)
 
     with patch.object(app, "questions", mock_questions):
-        with client.session_transaction() as sess:
+        with granted_access.session_transaction() as sess:
             # Ensure a clean state to trigger init logic
             sess.pop("current_question_index", None)
             sess.pop("survey_iteration", None)
 
-        response = client.get("/survey")
+        response = granted_access.get("/survey")
 
         # The first mock question has justification_enabled False
         justification_text = "Why we ask this question"
@@ -148,23 +148,23 @@ def test_survey_question_justification_disabled(client, mock_questions) -> None:
 
 
 @pytest.mark.route
-def test_survey_question_guidance_disabled(client, mock_questions) -> None:
+def test_survey_question_guidance_disabled(granted_access, mock_questions) -> None:
     """Tests that the survey route does not contain guidance,
      the guidance_enabled is false and returns a 200 OK response.
 
     Args:
-        client: Flask test client fixture.
+        granted_access: Flask test client fixture.
         mock_questions: Mocked questions to simulate survey data.
     """
     app = cast(SurveyAssistFlask, current_app)
 
     with patch.object(app, "questions", mock_questions):
-        with client.session_transaction() as sess:
+        with granted_access.session_transaction() as sess:
             # Ensure a clean state to trigger init logic
             sess.pop("current_question_index", None)
             sess.pop("survey_iteration", None)
 
-        response = client.get("/survey")
+        response = granted_access.get("/survey")
 
         # The first mock question has guidance_enabled False
         guidance_text = "Guidance Text"
@@ -178,24 +178,24 @@ QUESTION_TWO_INDEX = 1
 
 
 @pytest.mark.route
-def test_survey_question_justification_enabled(client, mock_questions) -> None:
+def test_survey_question_justification_enabled(granted_access, mock_questions) -> None:
     """Tests that the survey route does not contain a justification,
      the justification_enabled is false and returns a 200 OK response.
 
     Args:
-        client: Flask test client fixture.
+        granted_access: Flask test client fixture.
         mock_questions: Mocked questions to simulate survey data.
     """
     app = cast(SurveyAssistFlask, current_app)
 
     with patch.object(app, "questions", mock_questions):
-        with client.session_transaction() as sess:
+        with granted_access.session_transaction() as sess:
             # Ensure a clean state to trigger init logic
             # Question two has functionality enabled
             sess["current_question_index"] = QUESTION_TWO_INDEX
             sess.modified = True
 
-        response = client.get("/survey")
+        response = granted_access.get("/survey")
 
         # The second mock question has justification_enabled True
         justification_title = "Why we ask this question"
@@ -211,24 +211,24 @@ def test_survey_question_justification_enabled(client, mock_questions) -> None:
 
 
 @pytest.mark.route
-def test_survey_question_guidance_enabled(client, mock_questions) -> None:
+def test_survey_question_guidance_enabled(granted_access, mock_questions) -> None:
     """Tests that the survey route does not contain guidance,
      the guidance_enabled is false and returns a 200 OK response.
 
     Args:
-        client: Flask test client fixture.
+        granted_access: Flask test client fixture.
         mock_questions: Mocked questions to simulate survey data.
     """
     app = cast(SurveyAssistFlask, current_app)
 
     with patch.object(app, "questions", mock_questions):
-        with client.session_transaction() as sess:
+        with granted_access.session_transaction() as sess:
             # Ensure a clean state to trigger init logic
             # Question two has functionality enabled
             sess["current_question_index"] = QUESTION_TWO_INDEX
             sess.modified = True
 
-        response = client.get("/survey")
+        response = granted_access.get("/survey")
 
         # The second mock question has guidance_enabled True
         guidance_text = "Guidance Text"
@@ -242,24 +242,24 @@ QUESTION_THREE_INDEX = 2
 
 
 @pytest.mark.route
-def test_placeholder_survey_question(client, mock_questions) -> None:
+def test_placeholder_survey_question(granted_access, mock_questions) -> None:
     """Tests that the survey route contains correct text
     for the first question and returns a 200 OK response.
 
     Args:
-        client: Flask test client fixture.
+        granted_access: Flask test client fixture.
         mock_questions: Mocked questions to simulate survey data.
     """
     app = cast(SurveyAssistFlask, current_app)
 
     with patch.object(app, "questions", mock_questions):
-        with client.session_transaction() as sess:
+        with granted_access.session_transaction() as sess:
             sess["current_question_index"] = QUESTION_THREE_INDEX
 
             sess["response"] = {"job_title": "Warehouse Manager"}
             sess.modified = True
 
-        response = client.get("/survey")
+        response = granted_access.get("/survey")
         expected_text = mock_questions[QUESTION_THREE_INDEX]["question_text"].replace(
             "PLACEHOLDER_TEXT", "Warehouse Manager"
         )
@@ -273,11 +273,11 @@ def test_placeholder_survey_question(client, mock_questions) -> None:
 
 
 @pytest.mark.route
-def test_survey_assist_consent(client, mock_survey_assist) -> None:
+def test_survey_assist_consent(granted_access, mock_survey_assist) -> None:
     """Tests that the consent route returns a 200 OK response.
 
     Args:
-        client: Flask test client fixture.
+        granted_access: Flask test client fixture.
         mock_survey_assist: Mocked survey assist data.
     """
     app = cast(SurveyAssistFlask, current_app)
@@ -285,7 +285,7 @@ def test_survey_assist_consent(client, mock_survey_assist) -> None:
     route_text = "survey_assist_consent"
 
     with patch.object(app, "survey_assist", mock_survey_assist):
-        response = client.get("/" + route_text)
+        response = granted_access.get("/" + route_text)
         assert (
             response.status_code == HTTPStatus.OK
         ), "{route_text} should return 200 OK"
@@ -295,20 +295,20 @@ def test_survey_assist_consent(client, mock_survey_assist) -> None:
 
 
 @pytest.mark.route
-def test_survey_summary(client, mock_survey_iteration) -> None:
+def test_survey_summary(granted_access, mock_survey_iteration) -> None:
     """Tests that the survey summary route returns a 200 OK response.
 
     Args:
-        client: Flask test client fixture.
+        granted_access: Flask test client fixture.
         mock_survey_iteration: Mocked survey iteration data.
     """
     route_text = "summary"
 
-    with client.session_transaction() as sess:
+    with granted_access.session_transaction() as sess:
         sess["survey_iteration"] = mock_survey_iteration
         sess.modified = True
 
-    response = client.get("/" + route_text)
+    response = granted_access.get("/" + route_text)
     assert response.status_code == HTTPStatus.OK, "{route_text} should return 200 OK"
     assert (
         b"Summary" in response.data
@@ -316,14 +316,14 @@ def test_survey_summary(client, mock_survey_iteration) -> None:
 
 
 @pytest.mark.route
-def test_thank_you_route(client) -> None:
+def test_thank_you_route(granted_access) -> None:
     """Tests that the survey thank you route contains survey title and returns a 200 OK response.
 
     Args:
-        client: Flask test client fixture.
+        granted_access: Flask test client fixture.
     """
     app = cast(SurveyAssistFlask, current_app)
-    response = client.get("/thank_you")
+    response = granted_access.get("/thank_you")
     expected_text = app.survey_title
 
     assert (
@@ -333,13 +333,13 @@ def test_thank_you_route(client) -> None:
 
 
 @pytest.mark.route
-def test_feedback_intro_route(client) -> None:
+def test_feedback_intro_route(granted_access) -> None:
     """Tests that the feedback intro route contains survey title and returns a 200 OK response.
 
     Args:
-        client: Flask test client fixture.
+        granted_access: Flask test client fixture.
     """
-    response = client.get("/feedback_intro")
+    response = granted_access.get("/feedback_intro")
     expected_text = "feedback on your experience today"
 
     assert (
@@ -351,22 +351,22 @@ def test_feedback_intro_route(client) -> None:
 
 
 @pytest.mark.route
-def test_first_feedback_question(client, mock_feedback) -> None:
+def test_first_feedback_question(granted_access, mock_feedback) -> None:
     """Tests that the feedback route contains correct text
     for the first feedback question and returns a 200 OK response.
 
     Args:
-        client: Flask test client fixture.
+        granted_access: Flask test client fixture.
         mock_feedback: Mocked feedback to simulate survey data.
     """
     app = cast(SurveyAssistFlask, current_app)
 
     with patch.object(app, "feedback", mock_feedback):
-        with client.session_transaction() as sess:
+        with granted_access.session_transaction() as sess:
             # Ensure a clean state to trigger init logic
             sess.pop("current_feedback_index", None)
 
-        response = client.get("/feedback")
+        response = granted_access.get("/feedback")
 
         mock_feedback_questions = mock_feedback.get("questions")
 
@@ -380,19 +380,19 @@ def test_first_feedback_question(client, mock_feedback) -> None:
         ), "Expected 'Save and continue' in response"
 
         # Validate session was initialised correctly
-        with client.session_transaction() as sess:
+        with granted_access.session_transaction() as sess:
             assert "current_feedback_index" in sess
             assert sess["current_feedback_index"] == FIRST_QUESTION
 
 
 @pytest.mark.route
-def test_feedback_thank_you_route(client) -> None:
+def test_feedback_thank_you_route(granted_access) -> None:
     """Tests that the feedback thank you route contains survey title and returns a 200 OK response.
 
     Args:
-        client: Flask test client fixture.
+        granted_access: Flask test client fixture.
     """
-    response = client.get("/feedback_thank_you")
+    response = granted_access.get("/feedback_thank_you")
     expected_text = "Feedback has been successfully submitted"
 
     assert (

--- a/utils/access_utils.py
+++ b/utils/access_utils.py
@@ -8,6 +8,8 @@ import csv
 import os
 import re
 
+from flask import redirect, session
+from flask.typing import ResponseReturnValue
 from survey_assist_utils.logging import get_logger
 
 logger = get_logger(__name__, level="DEBUG")
@@ -64,3 +66,19 @@ def format_access_code(raw: str) -> str:
     """
     # trims ends and turns any run of spaces/tabs into a single hyphen
     return re.sub(r"\s+", "-", raw.strip()).upper()
+
+
+def require_access() -> ResponseReturnValue | None:
+    """Checks if participant access credentials are present in the session.
+
+    If either 'participant_id' or 'access_code' is missing from the session,
+    redirects the user to the access page. Otherwise, allows the request to proceed.
+
+    Returns:
+        Response or None: Redirects to the access page if credentials are missing,
+        otherwise None to allow further processing.
+    """
+    if "participant_id" not in session and "access_code" not in session:
+        return redirect("/access")
+    # else allow
+    return None

--- a/utils/access_utils.py
+++ b/utils/access_utils.py
@@ -1,0 +1,32 @@
+"""Access utility functions.
+
+This module provides an functionality used to verify access to the Survey Assist UI.
+
+"""
+import csv
+import os
+
+from survey_assist_utils.logging import get_logger
+
+logger = get_logger(__name__, level="DEBUG")
+
+FILENAME = "example_access.csv"
+def validate_access(access_id: str, access_code: str) -> bool:
+    """STUBBED - Validate the user against the credentials in a local file."""
+    try:
+        if not os.path.exists(FILENAME):
+            print(f"Access file '{FILENAME}' not found.")
+            return False
+
+        with open(FILENAME, newline="", encoding="utf-8") as csvfile:
+            reader = csv.DictReader(csvfile)
+            for row in reader:
+                if (
+                    row.get("survey_access_id") == access_id
+                    and row.get("one_time_passcode") == access_code
+                ):
+                    return True
+        return True
+    except Exception as e:
+        print(f"Error validating user: {e}")
+    return False

--- a/utils/access_utils.py
+++ b/utils/access_utils.py
@@ -3,20 +3,37 @@
 This module provides an functionality used to verify access to the Survey Assist UI.
 
 """
+
 import csv
 import os
+import re
 
 from survey_assist_utils.logging import get_logger
 
 logger = get_logger(__name__, level="DEBUG")
 
 FILENAME = "example_access.csv"
-def validate_access(access_id: str, access_code: str) -> bool:
-    """STUBBED - Validate the user against the credentials in a local file."""
+
+
+def validate_access(access_id: str, access_code: str) -> tuple[bool, str]:
+    """STUBBED - Validate the user against the credentials in a local file.
+
+    Args:
+        access_id (str): The user's access identifier.
+        access_code (str): The access code to validate.
+
+    Returns:
+        tuple[bool, str]: Tuple of (True, "") if valid, or (False, error message) if not.
+    """
+    logger.debug(f"Validate access for {access_id} : {access_code}")
+    error_string = "Invalid credentials. Please try again."
+    if not access_code:
+        logger.warning(f"Empty access code entered for access_id: {access_id}")
+        return False, "You must enter both ONS ID and PFR ID"
     try:
         if not os.path.exists(FILENAME):
-            print(f"Access file '{FILENAME}' not found.")
-            return False
+            logger.error(f"Access file '{FILENAME}' not found.")
+            return False, error_string
 
         with open(FILENAME, newline="", encoding="utf-8") as csvfile:
             reader = csv.DictReader(csvfile)
@@ -25,8 +42,25 @@ def validate_access(access_id: str, access_code: str) -> bool:
                     row.get("survey_access_id") == access_id
                     and row.get("one_time_passcode") == access_code
                 ):
-                    return True
-        return True
-    except Exception as e:
-        print(f"Error validating user: {e}")
-    return False
+                    return True, ""
+        logger.warning(f"Validation unsuccessful for id: {access_id}")
+        return False, error_string
+    except Exception as e:  # pylint: disable=broad-exception-caught
+        logger.warning(f"Error validating user: {e}")
+    return False, "Error in validation module"
+
+
+def format_access_code(raw: str) -> str:
+    """Convert whitespace in an access code to hyphens and ensure uppercase.
+
+    Trims leading and trailing whitespace, and replaces any sequence of spaces or tabs
+    within the string with a single hyphen.
+
+    Args:
+        raw (str): The raw access code string to format.
+
+    Returns:
+        str: The formatted access code as uppercase with hyphens.
+    """
+    # trims ends and turns any run of spaces/tabs into a single hyphen
+    return re.sub(r"\s+", "-", raw.strip()).upper()

--- a/utils/api_utils.py
+++ b/utils/api_utils.py
@@ -9,6 +9,7 @@ poetry run python scripts/run_api.py --type sic --action classify
 poetry run python scripts/run_api.py --type sic --action both
 """
 
+import subprocess
 from http import HTTPStatus
 from typing import Optional
 
@@ -274,3 +275,14 @@ def map_to_lookup_response(
         potential_codes=potential_codes,
         potential_divisions=potential_divisions,
     )
+
+
+def get_verification_api_id_token():
+    """Generate a Google ID token for the firestore-otp-api."""
+    # Lint errors are ok to ignore since the code does not pass user input
+    # to the subprocess, values are hardcoded and therefore valid
+    gcloud_print_id_token = subprocess.check_output(  # noqa: S603
+        ["gcloud", "auth", "print-identity-token"]  # noqa: S607
+    )
+    id_token = gcloud_print_id_token.decode().strip()
+    return id_token

--- a/utils/app_types.py
+++ b/utils/app_types.py
@@ -18,10 +18,13 @@ class SurveyAssistFlask(Flask):
     """Custom Flask app class with additional attributes for Survey Assist.
 
     Attributes:
-        api_client (Any): The API client instance for external requests.
-        api_base (str): The base URL for the API.
-        api_ver (str): The version of the API (defaults to v1).
-        api_token (str): The API authentication token.
+        api_client (Any): The Survey Assist API client instance for external requests.
+        api_base (str): The base URL for the Survey Assist API.
+        api_ver (str): The version of the Survey Assist API (defaults to v1).
+        api_token (str): The Survey Assist API authentication token.
+        verify_api_client (Any): The Verify client instance for external auth requests.
+        verify_api_base (str): The base URL for the Verify API.
+        verify_api_token (str): The Verify API authentication token.
         sa_email (str): Survey Assist service account.
         survey_title (str): Title of the survey.
         survey_intro (bool): Is survey intro enabled or not.
@@ -37,6 +40,9 @@ class SurveyAssistFlask(Flask):
     api_base: str
     api_ver: str
     api_token: str
+    verify_api_client: Any
+    verify_api_base: str
+    verify_api_token: str
     sa_email: str
     survey_title: str
     survey_intro: bool

--- a/utils/session_utils.py
+++ b/utils/session_utils.py
@@ -22,7 +22,6 @@ from models.result import (
     GenericSurveyAssistResult,
     InputField,
 )
-from utils.access_utils import delete_access
 from utils.api_utils import map_to_lookup_response
 
 T = TypeVar("T", bound=BaseModel)
@@ -191,7 +190,7 @@ def remove_model_from_session(key: str) -> None:
 def remove_access_from_session() -> None:
     """Remove access grant from the verify API and Flask session."""
     logger.warning("TBD - Must add delete Access Code Functionality")
-    #delete_access(session.get("participant_id", ""))
+    # delete_access(session.get("participant_id", ""))
 
     session.pop("participant_id", None)
     session.pop("access_code", None)

--- a/utils/session_utils.py
+++ b/utils/session_utils.py
@@ -22,6 +22,7 @@ from models.result import (
     GenericSurveyAssistResult,
     InputField,
 )
+from utils.access_utils import delete_access
 from utils.api_utils import map_to_lookup_response
 
 T = TypeVar("T", bound=BaseModel)
@@ -184,6 +185,17 @@ def load_model_from_session(key: str, model_class: type[T]) -> T:
 def remove_model_from_session(key: str) -> None:
     """Remove a model from the Flask session."""
     session.pop(key, None)
+    session.modified = True
+
+
+def remove_access_from_session() -> None:
+    """Remove access grant from the verify API and Flask session."""
+    logger.warning("TBD - Must add delete Access Code Functionality")
+    #delete_access(session.get("participant_id", ""))
+
+    session.pop("participant_id", None)
+    session.pop("access_code", None)
+
     session.modified = True
 
 


### PR DESCRIPTION
# 📌 Add Access Page to UI

## ✨ Summary
This PR adds:

- A UI for entering ONS provided, ID and Access Code.
- Interaction with the Verify API Service (see (firestore-otp)[https://github.com/ONSdigital/firestore-otp]) using an auto generated client and pydantic models (see (firestore-otp-verification-api-client)[https://github.com/ONSdigital/firestore-otp-verification-api-client]).
- Protection for necessary routes to ensure ID and Access Code are verified.
- Utility functions to verify and delete access credentials.
- CLI script for ad-hoc manual test is updated to include root-otp, verify-otp, and delete-otp actions. 

Note: 
- **For developer testing** deletion of access code has been disabled, this will be added in prior to production. It negates the need to frequently generate new credentials.
- pytest suite is becoming large and could do with a clean up, this will be added to the backlog to attack once key reqs are complete.
- A new environment variable VERIFY_API_URL is introduced by this PR.


## 📜 Changes Introduced

- [x] Feature implementation (feat:) 
- [x] Updates to tests and/or documentation

## ✅ Checklist

- [x] Code is formatted using **Black**
- [x] Imports are sorted using **isort**
- [x] Code passes linting with **Ruff**, **Pylint**, and **Mypy**
- [x] Security checks pass using **Bandit**
- [x] Tests are written and pass using **pytest**
- [x] DocStrings follow Google-style and are added as per Pylint recommendations
- [x] Documentation has been updated if needed

## 🔍 How to Test

The code is currently running in the sandbox environment.  In this environment you can locate a list of active credentials that can be used for testing.  For guidance you can test:

1. Valid ID and Access Code allows access to survey and entire survey can be completed without issue.
2. Invalid ID does not allow access and returns an appropriate message to the user.
3. Invalid Access Code does not allow access and returns an appropriate message to the user.
4. ID must be entered.
5. If ID is entered but Access Code is not a suitable error message is displayed. 

**Locally**
You must have environment variables set (including VERIFY_API_URL, which is the URL of the running service in GCP)

You need to have logged in to gcloud and set the correct project:

```bash
gcloud auth login
gcloud config set project <sandbox>
```

You need to have authenticated for adc and ensure the quota project is correct:

```bash
gcloud auth application-default login
gcloud auth application-default set-quota-project <sandbox>
```
 
You need to have the following environment variables set:

```bash 
export SA_EMAIL=backend-api-access@<gcp env>
export BACKEND_API_URL=https://survey-assist-api-gw-.../
export BACKEND_API_VERSION = v1
export VERIFY_API_URL=https://firestore-otp-api-.../
```

You can run the unit tests:
```
make all-tests
```

You can also run the cli tool to verify connection with the verification service:

